### PR TITLE
Adds oms_internal.h

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -8,6 +8,7 @@ signedmediaframework_public_headers = files(
 
 signedmediaframework_sources = files(
   'oms_defines.h',
+  'oms_internal.h',
   'oms_openssl.c',
   'oms_openssl_internal.h',
   'oms_tmp_definitions.c',

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -1,0 +1,243 @@
+/************************************************************************************
+ * Copyright (c) 2024 ONVIF.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of ONVIF nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ONVIF BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ************************************************************************************/
+
+#ifndef __OMS_INTERNAL_H__
+#define __OMS_INTERNAL_H__
+
+#include <stdbool.h>
+#include <stdint.h>  // uint8_t
+#include <stdlib.h>  // size_t
+
+#include "includes/onvif_media_signing_common.h"  // MediaSigningReturnCode, signed_video_product_info_t
+#include "oms_defines.h"  // oms_rc
+#include "oms_openssl_internal.h"  // pem_pkey_t, sign_or_verify_data_t
+
+typedef struct _gop_info_t gop_info_t;
+typedef struct _sei_data_t sei_data_t;
+#ifdef VALIDATION_SIDE
+typedef struct _validation_flags_t validation_flags_t;
+typedef struct _gop_state_t gop_state_t;
+#endif
+// Forward declare nalu_list_t here for onvif_media_signing_t.
+// typedef struct _nalu_list_t nalu_list_t;
+typedef struct _nalu_t nalu_t;
+
+// #if defined(_WIN32) || defined(_WIN64)
+// #define ATTR_UNUSED
+// #else
+// #define ATTR_UNUSED __attribute__((unused))
+// #endif
+
+#define OMS_VERSION_BYTES 3
+#define ONVIF_MEDIA_SIGNING_VERSION "v0.0.0"
+#define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
+
+#define DEFAULT_MAX_GOP_LENGTH 300
+
+// Maximum number of ongoing and completed SEIs to hold until the user fetches them
+#define MAX_SEI_DATA_BUFFER 60
+// #define UUID_LEN 16
+// #define LAST_TWO_BYTES_INIT_VALUE 0x0101  // Anything but 0x00 are proper init values
+// #define STOP_BYTE_VALUE 0x80
+
+// #ifndef ARRAY_SIZE
+// #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+// #endif
+
+/* Compile time defined, otherwise set default value */
+#ifndef MAX_GOP_LENGTH
+#define MAX_GOP_LENGTH DEFAULT_MAX_GOP_LENGTH
+#endif
+
+// Currently the largest supported hash is SHA-512.
+#define MAX_HASH_SIZE (512 / 8)
+// Size of the default hash (SHA-256).
+#define DEFAULT_HASH_SIZE (256 / 8)
+#define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_GOP_LENGTH)
+
+#ifdef VALIDATION_SIDE
+struct _validation_flags_t {
+  bool has_auth_result;  // Indicates that an authenticity result is available for the
+                         // user.
+  bool is_first_validation;  // Indicates if this is the first validation. If so, a
+                             // failing validation result is not necessarily true, since
+                             // the framework may be out of sync, e.g., after exporting to
+                             // a file.
+  bool reset_first_validation;  // Indicates if this a second attempt of a first
+                                // validation should be performed. Hence, flag a reset.
+  bool signing_present;  // Indicates if ONVIF Media Signing is present or not. It is only
+                         // possible to move from false to true unless a reset is
+                         // performed.
+  bool is_first_sei;  // Indicates that this is the first received SEI.
+  bool hash_algo_known;  // Information on what hash algorithm to use has been received.
+};
+
+struct _gop_state_t {
+  bool has_sei;  // The GOP includes a SEI.
+  bool has_lost_sei;  // Has detected a lost SEI since last validation.
+  bool no_gop_end_before_sei;  // No GOP end (I-frame) has been found before the SEI.
+  bool gop_transition_is_lost;  // The transition between GOPs has been lost. This can be
+                                // detected if a lost SEI is detected, and at the same
+                                // time waiting for an 'I'. An example when this happens
+                                // is if an entire AU is lost including both the SEI and
+                                // the 'I'.
+};
+#endif
+
+// Buffer of |last_two_bytes| and pointers to |sei| memory and current |write_position|.
+// Writing of the SEI is split in time and it is therefore necessary to pick up the value
+// of |last_two_bytes| when we continue writing with emulation prevention turned on. As
+// soon as a SEI is completed, the |completed_sei_size| is filled in.
+struct _sei_data_t {
+  uint8_t *sei;  // Pointer to the allocated SEI data
+  uint8_t *write_position;
+  uint16_t last_two_bytes;
+  size_t completed_sei_size;  // The final SEI size, set when it is completed
+};
+
+struct _onvif_media_signing_t {
+  // Members common to both signing and validation
+  int code_version[OMS_VERSION_BYTES];
+  MediaSigningReturnCode codec;  // Codec used in this session.
+  onvif_media_signing_product_info_t *product_info;
+
+  // For cryptographic functions, like OpenSSL
+  void *crypto_handle;
+  pem_pkey_t pem_public_key;  // Public key in PEM form for writing/reading to/from SEIs
+  gop_info_t *gop_info;
+
+  // Arbitrary data
+  uint8_t *arbitrary_data;  // Enables the user to transmit user specific data and is
+                            // automatically
+  // sent through the ARBITRARY_DATA_TAG.
+  size_t arbitrary_data_size;  // Size of |arbitrary_data|.
+
+  // Members only used for signing
+
+  // Configuration members
+  size_t max_sei_payload_size;  // Default 0 = unlimited
+
+  // Flags
+  bool sei_epb;  // Flag that tells whether to generate SEI frames w/wo emulation
+                 // prevention bytes
+  bool is_golden_sei;  // Flag that tells if a SEI is a golden SEI
+  bool signing_started;
+
+  // For signing plugin
+  void *plugin_handle;
+  sign_or_verify_data_t *sign_data;  // All necessary information to sign in a plugin.
+
+  nalu_t *last_nalu;  // Track last parsed nalu_t to pass on to next part
+
+  // Members associated with SEI writing
+  uint16_t last_two_bytes;
+  sei_data_t sei_data_buffer[MAX_SEI_DATA_BUFFER];
+  int sei_data_buffer_idx;
+  int num_of_completed_seis;
+
+#ifdef VALIDATION_SIDE
+  // Members only used for validation
+  // TODO: Collect everything needed by the authentication part only in one struct/object,
+  // which then is not needed to be created on the signing side, saving some memory.
+
+  // Status and authentication
+  // Linked list to track the validation status of each added NAL Unit. Items are appended
+  // to the list when added, that is, in onvif_media_signing_add_nalu_and_authenticate().
+  // Items are removed when reported through the authenticity_report.
+  h26x_nalu_list_t *nalu_list;
+  bool authentication_started;
+
+  validation_flags_t validation_flags;
+  gop_state_t gop_state;
+  bool has_public_key;  // State to indicate if public key is received/added
+  // For signature verification
+  sign_or_verify_data_t *verify_data;  // All necessary information to verify a signature.
+
+  // Shortcuts to authenticity information.
+  // If no authenticity report has been set by the user the memory is allocated and used
+  // locally. Otherwise, these members point to the corresponding members in
+  // |authenticity| below.
+  signed_video_latest_validation_t *latest_validation;
+  signed_video_accumulated_validation_t *accumulated_validation;
+
+  signed_video_authenticity_t *authenticity;  // Pointer to the authenticity report of
+  // which results will be written.
+#endif
+};
+
+/**
+ * Information related to the GOP signature.
+ * The |gop_hash| is a recursive hash. It is the hash of the memory [gop_hash, latest
+ * hash] and then replaces the gop_hash location. This is used for signing, as it
+ * incorporates all information of the nalus that has been added.
+ */
+struct _gop_info_t {
+  uint8_t hash_buddies[2 *
+      MAX_HASH_SIZE];  // Memory for two hashes organized as [reference_hash, nalu_hash].
+  bool has_reference_hash;  // Flags if the reference hash in |hash_buddies| is valid.
+  uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes
+  size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than
+                          // allocated.
+  int hash_list_idx;  // Pointing to next available slot in the |hash_list|. If something
+                      // has gone wrong, like exceeding available memory, |list_idx| = -1.
+  uint8_t gop_hash_init;  // The initialization value for the |gop_hash|.
+  uint8_t *nalu_hash;  // Pointing to the memory slot of the NAL Unit hash in |hashes|.
+  uint8_t hash_to_sign[MAX_HASH_SIZE];  // Memory for storing the hash to be signed
+  uint8_t tmp_hash[MAX_HASH_SIZE];  // Memory for storing a temporary hash needed when a
+                                    // NAL Unit split in parts.
+  uint8_t *tmp_hash_ptr;
+  uint8_t encoding_status;  // Stores potential errors when encoding, to transmit to the
+                            // client (authentication part).
+  uint16_t num_sent_nalus;  // The number of NAL Units used to generate the gop_hash on
+                            // the signing side.
+  uint16_t num_nalus_in_gop_hash;  // Counted number of NAL Units in the currently
+                                   // recursively updated |gop_hash|.
+  uint32_t global_gop_counter;  // The index of the current GOP, incremented when encoded
+                                // in the TLV.
+  bool global_gop_counter_is_synced;  // Turns true when a SEI corresponding to the
+                                      // segment is detected.
+  int verified_signature;  // Status of last hash-signature-pair verification. Has 1 for
+                           // success, 0 for fail, and -1 for error.
+  int64_t timestamp;  // Unix epoch UTC timestamp of the first nalu in GOP
+};
+
+#if 0
+void
+bytes_to_version_str(const int *arr, char *str);
+
+/* Sets the allowed size of |hash_list|.
+ * Note that this can be different from what is allocated. */
+oms_rc
+set_hash_list_size(gop_info_t *gop_info, size_t hash_list_size);
+
+/* Defined in oms_signer.c */
+/* Frees all allocated memory of payload pointers in the SEI data buffer. */
+void
+free_sei_data_buffer(sei_data_t sei_data_buffer[]);
+#endif
+
+#endif  // __OMS_INTERNAL_H__

--- a/lib/src/oms_tmp_definitions.c
+++ b/lib/src/oms_tmp_definitions.c
@@ -31,6 +31,7 @@
 #include "includes/onvif_media_signing_common.h"
 #include "includes/onvif_media_signing_signer.h"
 #include "includes/onvif_media_signing_validator.h"
+#include "oms_internal.h"
 #include "oms_openssl_internal.h"
 
 /* Public onvif_media_signing_common.h APIs */
@@ -58,7 +59,7 @@ onvif_media_signing_free(onvif_media_signing_t *self)
 const char *
 onvif_media_signing_get_version()
 {
-  return "0.0.0";
+  return ONVIF_MEDIA_SIGNING_VERSION;
 }
 
 int


### PR DESCRIPTION
This header file includes the Media Signing object and
necessary sub-objects. Only signing side members have
been exposed. Others have been commented out.
