### PR TITLE
Enables crypto_handle in session struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ TODO: ADD REFERENCE TO SPECIFICATION.
 ## File structure
 ```
 signed-media-framework
+├── examples
 ├── lib
 |   ├── plugins
 |   |   ├── threaded-signing
@@ -64,17 +65,17 @@ repository will create a shared library named `libsigned-media-framework`.
 
 ## Configure with meson
 ```
-meson path/to/signed-media-framework path/to/build/folder
+meson setup path/to/signed-media-framework path/to/build/folder
 ```
 will generate compile instructions for ninja and put them in a folder located at
 `path/to/build/folder`. The framework comes with an option to build with debug prints
 ```
-meson -Ddebugprints=true path/to/signed-media-framework path/to/build/folder
+meson setup -Ddebugprints=true path/to/signed-media-framework path/to/build/folder
 ```
 With the `--prefix` meson option it is possible to specify an arbitrary location to where
 the shared library is installed.
 ```
-meson --prefix /absolute/path/to/your/local/installs path/to/signed-media-framework path/to/build/folder
+meson setup --prefix /absolute/path/to/your/local/installs path/to/signed-media-framework path/to/build/folder
 ```
 
 ## Compile and install the shared library
@@ -96,20 +97,20 @@ The header files will be located in a sub-folder of `includes` named
 ## Example build commands on Linux
 1. Configure and compile into `./build` without installing from the top level
 ```
-meson . build
+meson setup . build
 ninja -C build
 ```
 2. Configure, compile and install in `./my_installs/` from the parent folder of
 `signed-media-framework/`
 ```
-meson --prefix $PWD/my_installs signed-media-framework build
+meson setup --prefix $PWD/my_installs signed-media-framework build
 meson install -C build
 ```
 
 ## Configure, build and run unittests
 Nothing extra is needed. Hence, to build and run the unittests call
 ```
-meson . build
+meson setup . build
 ninja -C build test
 ```
 Alternatively, you can run the script

--- a/examples/apps/signer/gst-plugin/gstsigning.c
+++ b/examples/apps/signer/gst-plugin/gstsigning.c
@@ -205,7 +205,8 @@ add_nalus(GstSigning *signing, GstBuffer *current_au)
     oms_rc = onvif_media_signing_get_sei(signing->priv->media_signing, &sei);
   }
 
-  if (oms_rc != OMS_OK) goto get_nalu_failed;
+  if (oms_rc != OMS_OK)
+    goto get_nalu_failed;
 
   return add_count;
 
@@ -375,10 +376,10 @@ setup_signing(GstSigning *signing, GstCaps *caps)
   }
 
   // Send properties information to video library.
-  const onvif_media_signing_product_info_t product_info = {
-      .firmware_version = (char *)onvif_media_signing_get_version(),
-      .serial_number = "N/A",
-      .manufacturer = "Signed Media Framework"};
+  onvif_media_signing_product_info_t product_info = {0};
+  strcpy(product_info.firmware_version, onvif_media_signing_get_version());
+  strcpy(product_info.serial_number, "N/A");
+  strcpy(product_info.manufacturer, "Signed Media Framework");
   if (onvif_media_signing_set_product_info(priv->media_signing, &product_info) !=
       OMS_OK) {
     GST_ERROR_OBJECT(signing, "failed to set properties");

--- a/lib/src/includes/onvif_media_signing_common.h
+++ b/lib/src/includes/onvif_media_signing_common.h
@@ -38,12 +38,13 @@ typedef struct _onvif_media_signing_t onvif_media_signing_t;
  * Struct for holding strings to vendor product information
  *
  * This is used both by the device to set product information, and by the client to store
- * the sent information in the bundled authenticity report.
+ * the sent information in the bundled authenticity report. ONVIF Media Signing only
+ * supports names at most 256 bytes long for efficient transmission in SEIs.
  */
 typedef struct {
-  char* firmware_version;
-  char* serial_number;
-  char* manufacturer;
+  char firmware_version[257];
+  char serial_number[257];
+  char manufacturer[257];
 } onvif_media_signing_product_info_t;
 
 /**
@@ -56,8 +57,7 @@ typedef struct {
  * -(30-39): internal authentication errors
  *     -100: unknown failure
  */
-typedef enum
-{
+typedef enum {
   OMS_OK = 0,  // No error
   OMS_MEMORY = -1,  // Memory related failure
   OMS_INVALID_PARAMETER = -10,  // Invalid input parameter to function
@@ -74,8 +74,7 @@ typedef enum
  * Codecs supported by ONVIF Media Signing. This is necessary to provide when creating a
  * media signing session.
  */
-typedef enum
-{
+typedef enum {
   OMS_CODEC_H264 = 0,
   OMS_CODEC_H265 = 1,
   OMS_CODEC_NUM

--- a/lib/src/oms_openssl_internal.h
+++ b/lib/src/oms_openssl_internal.h
@@ -57,6 +57,28 @@ typedef struct _pem_pkey_t {
 } pem_pkey_t;
 
 /**
+ * @brief Creates a cryptographic handle
+ *
+ * Allocates the memory for a crypthographic |handle| holding specific OpenSSL
+ * information. This handle should be created when starting the session and freed at
+ * teardown with openssl_free_handle().
+ *
+ * @returns Pointer to the OpenSSL cryptographic handle.
+ */
+void *
+openssl_create_handle(void);
+
+/**
+ * @brief Frees a cryptographic handle
+ *
+ * Frees a crypthographic |handle| created with openssl_create_handle().
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ */
+void
+openssl_free_handle(void *handle);
+
+/**
  * @brief Signs a hash
  *
  * The function generates a signature of the |hash| in |sign_data| and stores the result


### PR DESCRIPTION
In addition, changed the onvif_media_signing_product_info_t to
have a static size memory to become more clear to the user about
the constraints when adding them to the SEI.
The example apps have been updated according to that.

The README has been updated with the examples folder in the tree.
