### PR TITLE
Adds NAL Unit to prepend and num_pending_seis to get sei API

### DIFF
--- a/examples/apps/signer/gst-plugin/gstsigning.c
+++ b/examples/apps/signer/gst-plugin/gstsigning.c
@@ -180,13 +180,16 @@ add_nalus(GstSigning *signing, GstBuffer *current_au)
   MediaSigningReturnCode oms_rc = OMS_UNKNOWN_FAILURE;
   gsize sei_size = 0;
   gint add_count = 0;
+  unsigned num_pending_seis = 0;
 
-  oms_rc = onvif_media_signing_get_sei(signing->priv->media_signing, NULL, &sei_size);
+  oms_rc = onvif_media_signing_get_sei(
+      signing->priv->media_signing, NULL, &sei_size, NULL, 0, &num_pending_seis);
   while (oms_rc == OMS_OK && sei_size > 0) {
     guint8 *sei = g_malloc0(sei_size);
     GstMemory *prepend_mem;
 
-    oms_rc = onvif_media_signing_get_sei(signing->priv->media_signing, sei, &sei_size);
+    oms_rc = onvif_media_signing_get_sei(
+        signing->priv->media_signing, sei, &sei_size, NULL, 0, &num_pending_seis);
     if (oms_rc != OMS_OK) {
       break;
     }
@@ -199,7 +202,8 @@ add_nalus(GstSigning *signing, GstBuffer *current_au)
     gst_buffer_prepend_memory(current_au, prepend_mem);
     add_count++;
 
-    oms_rc = onvif_media_signing_get_sei(signing->priv->media_signing, NULL, &sei_size);
+    oms_rc = onvif_media_signing_get_sei(
+        signing->priv->media_signing, NULL, &sei_size, NULL, 0, &num_pending_seis);
   }
 
   if (oms_rc != OMS_OK)

--- a/lib/src/includes/onvif_media_signing_signer.h
+++ b/lib/src/includes/onvif_media_signing_signer.h
@@ -231,17 +231,27 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
  * only in conjunction with primary slice NAL Units, like F0p in the example description
  * at the top of this file.
  *
- * @param self      Pointer to the ONVIF Media Signing session.
- * @param sei       A pointer to the memory of which the library will copy the SEI. A NULL
- *   pointer means that only the |sei_size| is written.
- * @param sei_size  A pointer to where the size of the SEI will be written. If zero, no
- *   SEI is available
+ * @param self                Pointer to the ONVIF Media Signing session.
+ * @param sei                 A pointer to the memory of which the library will copy the
+ *   SEI. A NULL pointer means that only the |sei_size| is written.
+ * @param sei_size            A pointer to where the size of the SEI will be written. If
+ *   zero, no SEI is available
+ * @param nal_to_prepend      A pointer to the NAL Unit of which the SEI will be prepended
+ *   as a header. SEIs can only be fetched if the NAL is a primary slice. A NULL pointer
+ *   means that the user is responsible to add the SEI according to standard.
+ * @param nal_to_prepend_size The size of the NAL to prepend.
+ * @param num_pending_seis    A pointer to where the number of pending SEIs is written.
  *
  * @returns OMS_OK            - SEI was pulled successfully, or no SEI was available,
  *          otherwise         - an error code.
  */
 MediaSigningReturnCode
-onvif_media_signing_get_sei(onvif_media_signing_t *self, uint8_t *sei, size_t *sei_size);
+onvif_media_signing_get_sei(onvif_media_signing_t *self,
+    uint8_t *sei,
+    size_t *sei_size,
+    const uint8_t *nal_to_prepend,
+    size_t nal_to_prepend_size,
+    unsigned *num_pending_seis);
 
 /**
  * @brief Sets the content of the signing key pair

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -155,9 +155,9 @@ START_TEST(api_inputs)
   ck_assert_int_eq(oms_rc, OMS_INVALID_PARAMETER);
 
   size_t sei_size = 0;
-  oms_rc = onvif_media_signing_get_sei(NULL, NULL, &sei_size);
+  oms_rc = onvif_media_signing_get_sei(NULL, NULL, &sei_size, NULL, 0, NULL);
   ck_assert_int_eq(oms_rc, OMS_INVALID_PARAMETER);
-  oms_rc = onvif_media_signing_get_sei(oms, NULL, 0);
+  oms_rc = onvif_media_signing_get_sei(oms, NULL, 0, NULL, 0, NULL);
   ck_assert_int_eq(oms_rc, OMS_INVALID_PARAMETER);
 
   // Checking onvif_media_signing_set_end_of_stream() for NULL pointers.


### PR DESCRIPTION
Now the user can get help when fetching SEIs. If SEIs are added to
the session at once (in place) it has to follow the standard and
SEIs should be part of other headers of a primary slice.
Also, it is possible to get information on how many SEIs there are
in the pipe, which can help the user to wait for ongoing signing.
