### PR TITLE
Implements various hashing schemes

### DIFF
--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -45,11 +45,11 @@ typedef struct _gop_state_t gop_state_t;
 // Forward declare nalu_list_t here for onvif_media_signing_t.
 // typedef struct _nalu_list_t nalu_list_t;
 
-// #if defined(_WIN32) || defined(_WIN64)
-// #define ATTR_UNUSED
-// #else
-// #define ATTR_UNUSED __attribute__((unused))
-// #endif
+#if defined(_WIN32) || defined(_WIN64)
+#define ATTR_UNUSED
+#else
+#define ATTR_UNUSED __attribute__((unused))
+#endif
 
 #define OMS_VERSION_BYTES 3
 #define ONVIF_MEDIA_SIGNING_VERSION "v0.0.0"
@@ -252,7 +252,7 @@ struct _onvif_media_signing_t {
 struct _gop_info_t {
   uint8_t hash_buddies[2 *
       MAX_HASH_SIZE];  // Memory for two hashes organized as [reference_hash, nalu_hash].
-  bool has_reference_hash;  // Flags if the reference hash in |hash_buddies| is valid.
+  bool has_anchor_hash;  // Flags if the reference hash in |hash_buddies| is valid.
   uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes
   size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than
                           // allocated.
@@ -287,6 +287,9 @@ parse_nalu_info(const uint8_t *nalu,
 
 void
 copy_nalu_except_pointers(nalu_info_t *dst_nalu, const nalu_info_t *src_nalu);
+
+oms_rc
+hash_and_add(onvif_media_signing_t *self, const nalu_info_t *nalu_info);
 
 #if 0
 void

--- a/lib/src/oms_openssl_internal.h
+++ b/lib/src/oms_openssl_internal.h
@@ -157,4 +157,72 @@ openssl_set_hash_algo(void *handle, const char *name_or_oid);
 size_t
 openssl_get_hash_size(void *handle);
 
+/**
+ * @brief Hashes data
+ *
+ * Uses the hash algorithm set through openssl_set_hash_algo() to hash data. The memory
+ * for the |hash| has to be pre-allocated by the user. Use openssl_get_hash_size() to get
+ * the hash size.
+ *
+ * This is a simplification for calling openssl_init_hash(), openssl_update_hash() and
+ * openssl_finalize_hash() done in one go.
+ *
+ * @param data Pointer to the data to hash.
+ * @param data_size Size of the |data| to hash.
+ * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
+ *
+ * @returns OMS_OK Successfully hashed |data|,
+ *          OMS_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
+ *          OMS_EXTERNAL_FAILURE Failed to hash.
+ */
+oms_rc
+openssl_hash_data(void *handle, const uint8_t *data, size_t data_size, uint8_t *hash);
+
+/**
+ * @brief Initiates the cryptographic handle for hashing data
+ *
+ * Uses the OpenSSL API EVP_DigestInit_ex() to initiate an EVP_MD_CTX object in |handle|.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ *
+ * @returns OMS_OK Successfully initialized EVP_MD_CTX object in |handle|,
+ *          OMS_INVALID_PARAMETER Null pointer input,
+ *          OMS_EXTERNAL_FAILURE Failed to initialize.
+ */
+oms_rc
+openssl_init_hash(void *handle);
+
+/**
+ * @brief Updates the cryptographic handle with |data| for hashing
+ *
+ * Uses the OpenSSL API EVP_DigestUpdate() to update the EVP_MD_CTX object in |handle|
+ * with |data|.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ * @param data Pointer to the data to update an ongoing hash.
+ * @param data_size Size of the |data|.
+ *
+ * @returns OMS_OK Successfully updated EVP_MD_CTX object in |handle|,
+ *          OMS_INVALID_PARAMETER Null pointer inputs, or invalid |data_size|,
+ *          OMS_EXTERNAL_FAILURE Failed to update.
+ */
+oms_rc
+openssl_update_hash(void *handle, const uint8_t *data, size_t data_size);
+
+/**
+ * @brief Finalizes the cryptographic handle and outputs the hash
+ *
+ * Uses the OpenSSL API EVP_DigestFinal_ex() to finalize the EVP_MD_CTX object in |handle|
+ * and get the |hash|. The EVP_MD_CTX object in |handle| is reset afterwards.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ * @param hash A pointer to the hashed output. This memory has to be pre-allocated.
+ *
+ * @returns OMS_OK Successfully wrote the final result of EVP_MD_CTX object in |handle| to
+ * |hash|, OMS_INVALID_PARAMETER Null pointer inputs, OMS_EXTERNAL_FAILURE Failed to
+ * finalize.
+ */
+oms_rc
+openssl_finalize_hash(void *handle, uint8_t *hash);
+
 #endif  // __OMS_OPENSSL_INTERNAL_H__

--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -354,7 +354,7 @@ generate_sei_nalu(onvif_media_signing_t *self,
     gop_info->list_idx = 0;
 
     // End of GOP. Reset flag to get new reference.
-    self->gop_info->has_reference_hash = false;
+    self->gop_info->has_anchor_hash = false;
     // Reset the timestamp to avoid including a duplicate in the next SEI.
     gop_info->has_timestamp = false;
 
@@ -496,7 +496,6 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
     // has been set.
     self->signing_started = true;
 
-    // OMS_THROW(hash_and_add(self, &nalu_info));
     // Depending on the input NAL Unit, different actions are taken. If the input is an
     // I-frame there is a transition to a new GOP. That triggers generating a SEI. While
     // being signed it is put in a buffer. For all other valid NALUs, simply hash and
@@ -520,8 +519,7 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
       // and add this first NALU of the GOP.
       // OMS_THROW(hash_and_add(self, &nalu_info));
     }
-    // TODO: Enable hashing when implemented
-    // OMS_THROW(hash_and_add(self, &nalu_info));
+    OMS_THROW(hash_and_add(self, &nalu_info));
   OMS_CATCH()
   OMS_DONE(status)
 


### PR DESCRIPTION
The OpenSSL wrappers now can hash using any valid hash algorithm.
It is now possible to update an ongoing hash and also hash with
or without an anchor.
