### PR TITLE
Implements the general information TLV tag

### DIFF
--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -230,7 +230,7 @@ gop_info_create(void)
     return NULL;
   }
 
-  gop_info->global_gop_counter = 0;
+  gop_info->current_gop = 0;
   // Initialize |verified_signature_hash| as 'error', since we lack data.
   gop_info->verified_signature = -1;
 
@@ -271,7 +271,7 @@ reset_gop_hash(onvif_media_signing_t *self)
   gop_info_t *gop_info = self->gop_info;
   assert(gop_info);
 
-  gop_info->num_nalus_in_gop_hash = 0;
+  gop_info->num_nalus_in_partial_gop = 0;
   return openssl_hash_data(self->crypto_handle, &gop_info->gop_hash_init, 1, gop_info->gop_hash);
 }
 
@@ -827,9 +827,9 @@ update_num_nalus_in_gop_hash(onvif_media_signing_t *self, const nalu_info_t *nal
   if (!self || !nalu_info) return;
 
   if (!nalu_info->is_gop_sei) {
-    self->gop_info->num_nalus_in_gop_hash++;
-    if (self->gop_info->num_nalus_in_gop_hash == 0) {
-      DEBUG_LOG("Wraparound in |num_nalus_in_gop_hash|");
+    self->gop_info->num_nalus_in_partial_gop++;
+    if (self->gop_info->num_nalus_in_partial_gop == 0) {
+      DEBUG_LOG("Wraparound in |num_nalus_in_partial_gop|");
       // This will not fail validation, but may produce incorrect statistics.
     }
   }

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -263,14 +263,16 @@ struct _gop_info_t {
   uint8_t tmp_hash[MAX_HASH_SIZE];  // Memory for storing a temporary hash needed when a
                                     // NAL Unit split in parts.
   uint8_t *tmp_hash_ptr;
+  uint8_t partial_gop_hash[MAX_HASH_SIZE];  // Memory for storing a (partial) GOP hash.
+  uint8_t linked_hash[MAX_HASH_SIZE];  // Memory for storing a linked hash.
   uint8_t encoding_status;  // Stores potential errors when encoding, to transmit to the
                             // client (authentication part).
   uint16_t num_sent_nalus;  // The number of NAL Units used to generate the gop_hash on
                             // the signing side.
-  uint16_t num_nalus_in_gop_hash;  // Counted number of NAL Units in the currently
-                                   // recursively updated |gop_hash|.
-  uint32_t global_gop_counter;  // The index of the current GOP, incremented when encoded
-                                // in the TLV.
+  uint16_t num_nalus_in_partial_gop;  // Counted number of NAL Units in the currently
+                                      // recursively updated |gop_hash|.
+  uint32_t current_gop;  // The index of the current GOP.
+
   bool global_gop_counter_is_synced;  // Turns true when a SEI corresponding to the
                                       // segment is detected.
   int verified_signature;  // Status of last hash-signature-pair verification. Has 1 for

--- a/lib/src/oms_tlv.h
+++ b/lib/src/oms_tlv.h
@@ -169,9 +169,8 @@ read_16bits(const uint8_t *p, uint16_t *val);
 size_t
 read_8bits(const uint8_t *p, uint8_t *val);
 
-#if 0
 /**
- * @brief Writes many bytes to payload w/wo emulation prevention
+ * @brief Writes many bytes to dst w/wo emulation prevention
  *
  * @param dst Location to write
  * @param src Location from where to read data
@@ -180,34 +179,47 @@ read_8bits(const uint8_t *p, uint8_t *val);
  */
 void
 write_byte_many(uint8_t **dst,
-    char *src,
+    uint8_t *src,
     size_t size,
     uint16_t *last_two_bytes,
     bool do_emulation_prevention);
-#endif
 
 /**
- * @brief Writes a byte to payload w/wo emulation prevention
+ * @brief Writes a byte to dst w/wo emulation prevention
  *
  * @param last_two_bytes For emulation prevention
- * @param payload Location write byte
+ * @param dst Location write byte
  * @param byte Byte to write
  * @param do_emulation_prevention If emulation prevention
  */
 void
 write_byte(uint16_t *last_two_bytes,
-    uint8_t **payload,
+    uint8_t **dst,
     uint8_t byte,
     bool do_emulation_prevention);
 
 /**
- * @brief Reads a byte from payload w/wo emulation prevention
+ * @brief Reads a byte from dst w/wo emulation prevention
  *
  * @returns The byte read.
  */
 uint8_t
-read_byte(uint16_t *last_two_bytes,
-    const uint8_t **payload,
+read_byte(uint16_t *last_two_bytes, const uint8_t **dst, bool do_emulation_prevention);
+
+/**
+ * @brief Reads many bytes to dst w/wo emulation prevention
+ *
+ * @param dst Location to write (NULL pointer is allowed for which the read value is
+ *   ignored)
+ * @param src Location from where to read data
+ * @param size Number of bytes to write to |dst|, usually size of |src|
+ * @param last_two_bytes For emulation prevention
+ */
+void
+read_byte_many(uint8_t *dst,
+    const uint8_t **src,
+    size_t size,
+    uint16_t *last_two_bytes,
     bool do_emulation_prevention);
 
 #endif  // __OMS_TLV_H__


### PR DESCRIPTION
In addition, adds two new members storing the GOP hash and the
linked hash. Further, made a new function to read multiple bytes,
for example, a hash.
