### PR TITLE
Implements encoding side of the crypto TLV tag

### DIFF
--- a/lib/src/oms_openssl.c
+++ b/lib/src/oms_openssl.c
@@ -493,17 +493,19 @@ openssl_set_hash_algo_by_encoded_oid(void *handle,
 
   return status;
 }
+#endif
 
 const unsigned char *
 openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
-  if (!self || encoded_oid_size == 0) return NULL;
+  if (!self || encoded_oid_size == 0) {
+    return NULL;
+  }
 
   *encoded_oid_size = self->hash_algo.encoded_oid_size;
   return (const unsigned char *)self->hash_algo.encoded_oid;
 }
-#endif
 
 size_t
 openssl_get_hash_size(void *handle)

--- a/lib/src/oms_openssl_internal.h
+++ b/lib/src/oms_openssl_internal.h
@@ -146,6 +146,20 @@ oms_rc
 openssl_set_hash_algo(void *handle, const char *name_or_oid);
 
 /**
+ * @brief Gets hashing algorithm on ASN.1/DER form
+ *
+ * Returns the hashing algorithm OID on serialized form, that is encoded as ASN.1/DER.
+ *
+ * @param handle Pointer to the OpenSSL cryptographic handle.
+ * @param encoded_oid_size A Pointer to where the size of the encoded OID is written.
+ *
+ * @returns A pointer to the encoded OID of the hashing algorithm,
+ *          and a NULL pointer upon failure.
+ */
+const unsigned char *
+openssl_get_hash_algo_encoded_oid(void *handle, size_t *encoded_oid_size);
+
+/**
  * @brief Gets the hash size of the hashing algorithm
  *
  * Returns the hash size of the hashing algorithm and 0 upon failure.


### PR DESCRIPTION
Adds a hash algo getter on OID serialized form.
Signing algorithm to be completed when supporting RSA. For EC
signing keys there is no need to transmit that information.
