### PR TITLE
Computes (partial) GOP hash

### DIFF
--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -119,31 +119,30 @@ version_str_to_bytes(int *arr, const char *str)
 //   sprintf(str, "v%d.%d.%d", arr[0], arr[1], arr[2]);
 // }
 
-#if 0
 #ifdef ONVIF_MEDIA_SIGNING_DEBUG
 char *
 nalu_type_to_str(const nalu_info_t *nalu_info)
 {
   switch (nalu_info->nalu_type) {
     case NALU_TYPE_SEI:
-      return "SEI-nalu_info";
+      return "SEI";
     case NALU_TYPE_I:
-      return nalu_info->is_primary_slice == true ? "I-nalu" : "i-nalu";
+      return nalu_info->is_primary_slice == true ? "I (primary)" : "i (not primary)";
     case NALU_TYPE_P:
-      return nalu_info->is_primary_slice == true ? "P-nalu" : "p-nalu";
+      return nalu_info->is_primary_slice == true ? "P (primary)" : "p (not primary)";
     case NALU_TYPE_PS:
       return "PPS/SPS/VPS";
     case NALU_TYPE_AUD:
       return "AUD";
     case NALU_TYPE_OTHER:
-      return "valid other nalu";
+      return "valid other NAL Unit";
     case NALU_TYPE_UNDEFINED:
     default:
-      return "unknown nalu";
+      return "unknown NAL Unit";
   }
 }
-#endif
 
+#if 0
 char
 nalu_type_to_char(const nalu_info_t *nalu_info)
 {
@@ -168,6 +167,7 @@ nalu_type_to_char(const nalu_info_t *nalu_info)
       return 'U';
   }
 }
+#endif
 #endif
 
 /* Declared in oms_internal.h */
@@ -1071,6 +1071,14 @@ hash_and_add(onvif_media_signing_t *self, const nalu_info_t *nalu_info)
       // The end of the NAL Unit has been reached. Update the hash list.
       check_and_copy_hash_to_hash_list(self, nalu_hash, hash_size);
     }
+#ifdef ONVIF_MEDIA_SIGNING_DEBUG
+    printf("Hash of %s: ", nalu_type_to_str(nalu_info));
+    for (size_t i = 0; i < hash_size; i++) {
+      printf("%02x", nalu_hash[i]);
+    }
+    printf("\n");
+#endif
+
   OMS_CATCH()
   {
     // If we fail, the |hash_list| is not trustworthy.

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -52,7 +52,7 @@ typedef struct _gop_state_t gop_state_t;
 #endif
 
 #define OMS_VERSION_BYTES 3
-#define ONVIF_MEDIA_SIGNING_VERSION "v0.0.0"
+#define ONVIF_MEDIA_SIGNING_VERSION "v0.0.4"
 #define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
 
 #define DEFAULT_MAX_GOP_LENGTH 300

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -806,6 +806,7 @@ START_TEST(limited_sei_payload_size)
 END_TEST
 #endif
 
+// #define TESTING
 static Suite *
 onvif_media_signing_signer_suite(void)
 {
@@ -819,11 +820,16 @@ onvif_media_signing_signer_suite(void)
 
   MediaSigningCodec s = 0;
   MediaSigningCodec e = NUM_SETTINGS;
+  MediaSigningCodec e1 = NUM_SETTINGS;
+#ifdef TESTING
+  e = 0;
+  e1 = 1;
+#endif
 
   // Add tests
   tcase_add_loop_test(tc, api_inputs, s, e);
   tcase_add_loop_test(tc, incorrect_operation, s, e);
-  tcase_add_loop_test(tc, correct_nalu_sequence_without_eos, s, e);
+  tcase_add_loop_test(tc, correct_nalu_sequence_without_eos, s, e1);
   //   tcase_add_loop_test(tc, correct_multislice_nalu_sequence_without_eos, s, e);
   //   tcase_add_loop_test(tc, correct_nalu_sequence_with_eos, s, e);
   //   tcase_add_loop_test(tc, correct_multislice_sequence_with_eos, s, e);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -36,7 +36,7 @@
 #define RSA_PRIVATE_KEY_ALLOC_BYTES 2000
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
 
-const int64_t g_testTimestamp = 42;
+const int64_t g_testTimestamp = 133620480301234567;  // 08:00:30.1234567 UTC June 5, 2024
 
 struct oms_setting settings[NUM_SETTINGS] = {
     {OMS_CODEC_H264, oms_generate_ecdsa_private_key, NULL, false},


### PR DESCRIPTION
When triggering a SEI the partial GOP hash is computed from the
hash list. Also, number of hashes part of the hash list is
computed.

Hash prints has been added and a better timestamp.
Further, made a helper function when processing a signature which
eliminates a debug print.
