### PR TITLE
Implements a SEI parser

### DIFF
--- a/lib/src/includes/onvif_media_signing_helpers.h
+++ b/lib/src/includes/onvif_media_signing_helpers.h
@@ -28,6 +28,9 @@
 #ifndef __ONVIF_MEDIA_SIGNING_HELPERS_H__
 #define __ONVIF_MEDIA_SIGNING_HELPERS_H__
 
+#ifdef PRINT_DECODED_SEI
+#include <stdint.h>  // uint8_t
+#endif
 #include <stdlib.h>  // size_t
 
 #include "onvif_media_signing_common.h"
@@ -71,5 +74,10 @@ oms_generate_rsa_private_key(const char *dir_to_key,
     size_t *private_key_size,
     char **certificate_chain,
     size_t *certificate_chain_size);
+
+#ifdef PRINT_DECODED_SEI
+void
+onvif_media_signing_parse_sei(uint8_t *nalu, size_t nalu_size, MediaSigningCodec codec);
+#endif
 
 #endif  // __ONVIF_MEDIA_SIGNING_HELPERS_H__

--- a/lib/src/oms_defines.h
+++ b/lib/src/oms_defines.h
@@ -41,6 +41,9 @@ typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Re
 #include <stdio.h>
 #define DEBUG_LOG(str, ...) printf("[DEBUG](%s): " str "\n", __func__, ##__VA_ARGS__)
 #else
+#ifdef PRINT_DECODED_SEI
+#include <stdio.h>
+#endif
 #define DEBUG_LOG(str, ...) ((void)0)
 #endif
 

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -293,10 +293,12 @@ copy_nalu_except_pointers(nalu_info_t *dst_nalu, const nalu_info_t *src_nalu);
 oms_rc
 hash_and_add(onvif_media_signing_t *self, const nalu_info_t *nalu_info);
 
-#if 0
+#ifdef PRINT_DECODED_SEI
 void
 bytes_to_version_str(const int *arr, char *str);
+#endif
 
+#if 0
 /* Sets the allowed size of |hash_list|.
  * Note that this can be different from what is allocated. */
 oms_rc

--- a/lib/src/oms_tlv.h
+++ b/lib/src/oms_tlv.h
@@ -100,6 +100,23 @@ tlv_list_encode_or_get_size(onvif_media_signing_t *self,
     size_t num_tags,
     uint8_t *data);
 
+#ifdef PRINT_DECODED_SEI
+/**
+ * @brief Decodes a SEI payload into the onvif_media_signing_t object.
+ *
+ * The data is assumed to have been written in a TLV format. This function parses data as
+ * long as there are more tags.
+ *
+ * @param self Pointer to the onvif_media_signing_t object.
+ * @param data Pointer to the data to read from.
+ * @param data_size Size of the data.
+ *
+ * @returns OMS_OK if decoding was successful, otherwise an error code.
+ */
+oms_rc
+tlv_decode(onvif_media_signing_t *self, const uint8_t *data, size_t data_size);
+#endif
+
 #if 0
 /**
  * @brief Scans the TLV part of a SEI payload and decodes all recurrent tags
@@ -118,21 +135,6 @@ bool
 tlv_find_and_decode_optional_tags(onvif_media_signing_t *self,
     const uint8_t *tlv_data,
     size_t tlv_data_size);
-
-/**
- * @brief Decodes a SEI payload into the onvif_media_signing_t object.
- *
- * The data is assumed to have been written in a TLV format. This function parses data as
- * long as there are more tags.
- *
- * @param self Pointer to the onvif_media_signing_t object.
- * @param data Pointer to the data to read from.
- * @param data_size Size of the data.
- *
- * @returns OMS_OK if decoding was successful, otherwise an error code.
- */
-oms_rc
-tlv_decode(onvif_media_signing_t *self, const uint8_t *data, size_t data_size);
 
 /**
  * @brief Scans the TLV part of a SEI payload and stops when a given tag is detected.

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,9 @@ endif
 if get_option('debugprints')
   add_global_arguments('-DONVIF_MEDIA_SIGNING_DEBUG', language : 'c')
 endif
+if get_option('parsesei')
+  add_global_arguments('-DPRINT_DECODED_SEI', language : 'c')
+endif
 
 signing_plugin = get_option('signingplugin')
 # Determine if 'threaded_unless_check_dep' should use 'threaded' or 'unthreaded'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,3 +18,7 @@ option('build_all_apps',
   type : 'boolean',
   value : false,
   description : 'Builds all apps')
+option('parsesei',
+  type : 'boolean',
+  value : false,
+  description : 'Parse SEI frames')

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -33,6 +33,7 @@
 #include "lib/src/includes/onvif_media_signing_helpers.h"
 #include "lib/src/includes/onvif_media_signing_signer.h"
 #include "test_helpers.h"
+#include "test_stream.h"
 
 #define TEST_DATA_SIZE 42
 static const char test_data[TEST_DATA_SIZE] = {0};
@@ -51,6 +52,22 @@ setup()
 static void
 teardown()
 {
+}
+
+static void
+parse_sei(test_stream_t *list)
+{
+  if (!list) {
+    return;
+  }
+#ifdef PRINT_DECODED_SEI
+  test_stream_item_t *item = list->first_item;
+  while (item) {
+    onvif_media_signing_parse_sei(item->data, item->data_size, list->codec);
+    item = item->next;
+  }
+#else
+#endif
 }
 
 /* Test description
@@ -241,6 +258,7 @@ START_TEST(correct_nalu_sequence_without_eos)
 
   test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPIPPIPP", settings[_i]);
   test_stream_check_types(list, "SIPPSIPPSIPPSIPPSIPPSIPP");
+  parse_sei(list);
   test_stream_free(list);
 }
 END_TEST

--- a/tests/check/test_stream.h
+++ b/tests/check/test_stream.h
@@ -56,7 +56,7 @@ typedef struct _test_stream_st {
   test_stream_item_t *last_item;  // Last NAL Unit in the stream
   int num_items;  // Number of NAL Units in the stream
   char types[MAX_NUM_ITEMS + 1];  // One extra for null termination.
-  MediaSigningCodec codec;  // H264 or H265
+  MediaSigningCodec codec;  // H.264 or H.265
 } test_stream_t;
 
 /**


### PR DESCRIPTION
It is possible to enable through the meson option 'parsesei'.
Not yet added to the signer app.

Further, fixes a bug in removing emulation prevention bytes.
