### PR TITLE
Adds test for emulation prevention

### DIFF
--- a/lib/src/includes/onvif_media_signing_signer.h
+++ b/lib/src/includes/onvif_media_signing_signer.h
@@ -341,14 +341,19 @@ onvif_media_signing_set_vendor_info(onvif_media_signing_t *self,
  *
  * Emulation prevention bytes (EPB) are used to prevent the decoder from detecting a start
  * code sequence in the middle of a NAL Unit. By default, the framework generates SEIs
- * with EPB written to the payload at once. With this API, the user can select to have
+ * without EPB written to the payload at once. With this API, the user can select to have
  * ONVIF Media Signing generate SEIs with or without EPBs.
  *
- * If this API is not used, SEI payload is written with EPBs, hence equivalent with
- * setting |enable| to 'true'.
+ * Typically a device that adds SEIs at once on a stream where emulation prevention is
+ * applied will configure Media Signing to apply EPB before signing (set to true). A
+ * device that lets the encoder add SEIs will configure Media Signing to not apply EPB
+ * before signing (set to false).
+ *
+ * If this API is not used, SEI payload is written without EPBs, hence equivalent with
+ * setting |enable| to 'false'.
  *
  * @param self   Pointer to the ONVIF Media Signing session.
- * @param enable SEI payload written with EPB (default True)
+ * @param enable SEI payload written with EPB (default False)
  *
  * @returns An ONVIF Media Signing Return Code.
  */

--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -550,10 +550,10 @@ remove_epb_from_sei_payload(nalu_info_t *nalu_info)
   nalu_info->tlv_size -= 1;  // Exclude the |reserved_byte| from TLV size.
   nalu_info->tlv_data = nalu_info->tlv_start_in_nalu_data;
   // Read flags from |reserved_byte|
-  nalu_info->with_epb =
-      (nalu_info->reserved_byte & 0x80);  // Hash with emulation prevention bytes
   nalu_info->is_golden_sei =
-      (nalu_info->reserved_byte & 0x40);  // The NALU is a golden SEI.
+      (nalu_info->reserved_byte & 0x80);  // The NAL Unit is a golden SEI.
+  nalu_info->with_epb =
+      (nalu_info->reserved_byte & 0x40);  // Hash with emulation prevention bytes
 
   if (nalu_info->emulation_prevention_bytes <= 0) {
     return;
@@ -1178,7 +1178,7 @@ onvif_media_signing_create(MediaSigningCodec codec)
     // Initialize signing members
     // Signing plugin is setup when the private key is set.
     self->signing_frequency = 1;
-    self->sei_epb = true;
+    self->sei_epb = false;
     self->signing_started = false;
     self->sign_data = sign_or_verify_data_create();
     self->sign_data->hash_size = openssl_get_hash_size(self->crypto_handle);

--- a/lib/src/oms_tlv.h
+++ b/lib/src/oms_tlv.h
@@ -135,6 +135,7 @@ bool
 tlv_find_and_decode_optional_tags(onvif_media_signing_t *self,
     const uint8_t *tlv_data,
     size_t tlv_data_size);
+#endif
 
 /**
  * @brief Scans the TLV part of a SEI payload and stops when a given tag is detected.
@@ -152,9 +153,11 @@ tlv_find_and_decode_optional_tags(onvif_media_signing_t *self,
  *   not found.
  */
 const uint8_t *
-tlv_find_tag(const uint8_t *tlv_data, size_t tlv_data_size, oms_tlv_tag_t tag, bool with_ep);
+tlv_find_tag(const uint8_t *tlv_data,
+    size_t tlv_data_size,
+    oms_tlv_tag_t tag,
+    bool with_ep);
 
-#endif
 /**
  * @brief Reads bits from p into val.
  *

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -49,9 +49,10 @@ struct oms_setting {
   generate_key_fcn_t generate_key;
   const char* hash_algo;
   bool low_bitrate_mode;
+  bool ep_before_signing;
 };
 
-#define NUM_SETTINGS 5
+#define NUM_SETTINGS 9
 extern struct oms_setting settings[NUM_SETTINGS];
 
 extern const int64_t g_testTimestamp;
@@ -70,12 +71,12 @@ get_initialized_media_signing(MediaSigningCodec codec,
 
 /* See function create_signed_nalus_int */
 test_stream_t*
-create_signed_nalus(const char* str, struct oms_setting settings);
+create_signed_nalus(const char* str, struct oms_setting setting);
 
 /* See function create_signed_nalus_int, with the diffrence that each NAL Unit is split in
  * two parts. */
 test_stream_t*
-create_signed_splitted_nalus(const char* str, struct oms_setting settings);
+create_signed_splitted_nalus(const char* str, struct oms_setting setting);
 
 /* Creates a test_stream_t with all the NAL Units produced after signing. This mimic what
  * leaves the camera.


### PR DESCRIPTION
Also, now a video stream is signed after the first GOP, hence no
empty-GOP SEI is produced at the beginning.
Further, incorrect num_pending_seis were reported with the
get_sei() API.

Finally, the default setting for emulation prevention is to not
hash with it.
