### PR TITLE
Adds signer test for NAL Units split in parts

### DIFF
--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -450,8 +450,10 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
     }
     OMS_THROW(hash_and_add(self, &nalu_info));
     // Mark the start of signing when the first NAL Unit is passed in and successfully
-    // been hashed.
-    self->signing_started = true;
+    // been hashed (all parts).
+    if (nalu_info.is_last_nalu_part) {
+      self->signing_started = true;
+    }
   OMS_CATCH()
   OMS_DONE(status)
 

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -705,6 +705,7 @@ START_TEST(correct_timestamp)
   free(sei_ts);
 }
 END_TEST
+#endif
 
 /* Test description
  * Same as correct_nalu_sequence_without_eos, but with splitted NAL Unit data.
@@ -714,12 +715,12 @@ START_TEST(correct_signing_nalus_in_parts)
   // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
   // |settings|; See signed_video_helpers.h.
 
-  test_stream_t *list = create_signed_splitted_nalus("IPPIPP", settings[_i]);
-  test_stream_check_types(list, "SIPPSIPP");
+  test_stream_t *list = create_signed_splitted_nalus("IPPIPPI", settings[_i]);
+  test_stream_check_types(list, "IPPSIPPSI");
+  verify_seis(list, settings[_i]);
   test_stream_free(list);
 }
 END_TEST
-#endif
 
 /* Test description
  * Verify the setter for generating SEI frames with or without emulation prevention bytes.
@@ -864,9 +865,9 @@ onvif_media_signing_signer_suite(void)
   //   tcase_add_loop_test(tc, fallback_to_gop_level, s, e);
   //   tcase_add_loop_test(tc, two_completed_seis_pending, s, e);
   //   tcase_add_loop_test(tc, two_completed_seis_pending_legacy, s, e);
-  tcase_add_loop_test(tc, undefined_nalu_in_sequence, s1, e1);
+  tcase_add_loop_test(tc, undefined_nalu_in_sequence, s, e);
   //   tcase_add_loop_test(tc, correct_timestamp, s, e);
-  //   tcase_add_loop_test(tc, correct_signing_nalus_in_parts, s, e);
+  tcase_add_loop_test(tc, correct_signing_nalus_in_parts, s1, e1);
   //   tcase_add_loop_test(tc, golden_sei_created, s, e);
   tcase_add_loop_test(tc, w_wo_emulation_prevention_bytes, s, e);
   tcase_add_loop_test(tc, limited_sei_payload_size, s, e);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -245,10 +245,9 @@ create_signed_nalus(const char *str, struct oms_setting setting)
 /* See function create_signed_nalus_int, with the diffrence that each NAL Unit is split in
  * two parts. */
 test_stream_t *
-create_signed_splitted_nalus(const char __attribute__((unused)) * str,
-    struct oms_setting __attribute__((unused)) setting)
+create_signed_splitted_nalus(const char *str, struct oms_setting setting)
 {
-  return NULL;
+  return create_signed_splitted_nalus_int(str, setting, false, true);
 }
 
 /* Creates a test_stream_t with all the NAL Units produced after signing. This mimic what

--- a/tests/check/test_stream.c
+++ b/tests/check/test_stream.c
@@ -542,9 +542,11 @@ test_stream_prepend_first_item(test_stream_t *list, test_stream_item_t *new_item
 void
 test_stream_check_types(const test_stream_t *list, const char *types)
 {
-  if (!list)
-    return;
-  ck_assert_int_eq(strcmp(list->types, types), 0);
+  if (!list) {
+    ck_assert(false);
+  } else {
+    ck_assert_int_eq(strcmp(list->types, types), 0);
+  }
 }
 
 /* Helper function to print test_stream_t members. */


### PR DESCRIPTION
Makes sure signing is started once all parts have been hashed.
