### PR TITLE
Adds signer test for emitting SEIs in correct order

### DIFF
--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -121,6 +121,27 @@ get_initialized_media_signing(MediaSigningCodec codec,
   return oms;
 }
 
+onvif_media_signing_t *
+get_initialized_media_signing_by_setting(struct oms_setting setting, bool new_private_key)
+{
+  MediaSigningReturnCode omsrc = OMS_UNKNOWN_FAILURE;
+  onvif_media_signing_t *oms =
+      get_initialized_media_signing(setting.codec, setting.generate_key, new_private_key);
+  ck_assert(oms);
+  ck_assert_int_eq(
+      onvif_media_signing_set_low_bitrate_mode(oms, setting.low_bitrate_mode), OMS_OK);
+  ck_assert_int_eq(
+      onvif_media_signing_set_low_bitrate_mode(oms, setting.low_bitrate_mode), OMS_OK);
+  ck_assert_int_eq(onvif_media_signing_set_hash_algo(oms, setting.hash_algo), OMS_OK);
+  omsrc = onvif_media_signing_set_emulation_prevention_before_signing(
+      oms, setting.ep_before_signing);
+  ck_assert_int_eq(omsrc, OMS_OK);
+  omsrc = onvif_media_signing_set_max_sei_payload_size(oms, setting.max_sei_payload_size);
+  ck_assert_int_eq(omsrc, OMS_OK);
+
+  return oms;
+}
+
 /* Pull SEIs from the onvif_media_signing_t session |oms| and prepend them to the test
  * stream |item|. */
 static void

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -69,6 +69,9 @@ onvif_media_signing_t*
 get_initialized_media_signing(MediaSigningCodec codec,
     generate_key_fcn_t generate_key,
     bool new_private_key);
+onvif_media_signing_t*
+get_initialized_media_signing_by_setting(struct oms_setting setting,
+    bool new_private_key);
 
 /* See function create_signed_nalus_int */
 test_stream_t*


### PR DESCRIPTION
This required an output buffer of the unthreaded signing plugin.
Also, added a new helper function to create and initialize a
session given a setting.
