### PR TITLE
Adds helper to generate RSA key pairs

### DIFF
--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -548,7 +548,10 @@ START_TEST(limited_sei_payload_size)
 
   struct oms_setting setting = settings[_i];
   // Select an upper payload limit which is less then the size of the last SEI.
-  const size_t max_sei_payload_size = 750;
+  size_t max_sei_payload_size = 750;
+  if (setting.generate_key == oms_generate_rsa_private_key) {
+    max_sei_payload_size += 200;  // Extra for RSA keys being larger than EC
+  }
   setting.max_sei_payload_size = max_sei_payload_size;
   test_stream_t *list = create_signed_nalus("IPPIPPPPPPPPPPPPIP", setting);
   test_stream_check_types(list, "IPPISPPPPPPPPPPPPISP");

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -38,6 +38,7 @@
 #define ECDSA_PRIVATE_KEY_ALLOC_BYTES 1000
 
 #define EC_KEY oms_generate_ecdsa_private_key
+#define RSA_KEY oms_generate_rsa_private_key
 
 const int64_t g_testTimestamp = 133620480301234567;  // 08:00:30.1234567 UTC June 5, 2024
 
@@ -52,6 +53,7 @@ struct oms_setting settings[NUM_SETTINGS] = {
     {OMS_CODEC_H265, EC_KEY, NULL, true, true, 0, false, 0, 1},
     // Special cases
     {OMS_CODEC_H264, EC_KEY, "sha512", false, true, 0, false, 0, 1},
+    {OMS_CODEC_H264, RSA_KEY, NULL, false, false, 0, false, 0, 1},
 };
 
 static char private_key_ecdsa[ECDSA_PRIVATE_KEY_ALLOC_BYTES];

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -56,7 +56,7 @@ struct oms_setting {
   unsigned signing_frequency;
 };
 
-#define NUM_SETTINGS 9
+#define NUM_SETTINGS 10
 extern struct oms_setting settings[NUM_SETTINGS];
 
 extern const int64_t g_testTimestamp;


### PR DESCRIPTION
Currently rely on default settings, that is,
RSA 2048 with sha256 and PSS padding.
