### PR TITLE
Adds skeleton code for add and validate API

### DIFF
--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -18,6 +18,7 @@ signedmediaframework_sources = files(
   'oms_tlv.c',
   'oms_tlv.h',
   'oms_tmp_definitions.c',
+  'oms_validator.c',
 )
 
 # Until plugin management is in place the plugin file(s) are added to the sources.

--- a/lib/src/oms_authenticity_report.c
+++ b/lib/src/oms_authenticity_report.c
@@ -50,6 +50,9 @@ authenticity_report_init(onvif_media_signing_authenticity_t *authenticity_report
 /* Create and free functions. */
 static onvif_media_signing_authenticity_t *
 authenticity_report_create();
+/* Setters. */
+static void
+set_authenticity_shortcuts(onvif_media_signing_t *self);
 #if 0
 /* Transfer functions. */
 static void
@@ -59,9 +62,6 @@ transfer_accumulated_validation(onvif_media_signing_accumulated_validation_t *ds
 static void
 update_accumulated_validation(const onvif_media_signing_latest_validation_t *latest,
     onvif_media_signing_accumulated_validation_t *accumulated);
-/* Setters. */
-static void
-set_authenticity_shortcuts(onvif_media_signing_t *signed_video);
 #endif
 
 /**
@@ -297,10 +297,11 @@ update_authenticity_report(onvif_media_signing_t *self)
     self->accumulated_validation->number_of_validated_nalus += number_of_validated_nalus;
   }
 }
+#endif
 
 /**
- * Sets shortcuts to parts in |authenticity|. No ownership is transferred so pointers can safely be
- * replaced.
+ * Sets shortcuts to parts in |authenticity|. No ownership is transferred so pointers can
+ * safely be replaced.
  */
 static void
 set_authenticity_shortcuts(onvif_media_signing_t *self)
@@ -309,7 +310,6 @@ set_authenticity_shortcuts(onvif_media_signing_t *self)
   self->latest_validation = &self->authenticity->latest_validation;
   self->accumulated_validation = &self->authenticity->accumulated_validation;
 }
-#endif
 
 /**
  * Function to get an authenticity report.
@@ -360,7 +360,6 @@ onvif_media_signing_get_authenticity_report(onvif_media_signing_t *self)
   return authenticity_report;
 }
 
-#if 0
 /**
  * Functions to create and free authenticity reports and members.
  */
@@ -368,18 +367,22 @@ onvif_media_signing_get_authenticity_report(onvif_media_signing_t *self)
 oms_rc
 create_local_authenticity_report_if_needed(onvif_media_signing_t *self)
 {
-  if (!self) return SVI_INVALID_PARAMETER;
+  if (!self) {
+    return OMS_INVALID_PARAMETER;
+  }
 
   // Already exists, return OMS_OK.
-  if (self->authenticity) return OMS_OK;
+  if (self->authenticity) {
+    return OMS_OK;
+  }
 
   oms_rc status = OMS_UNKNOWN_FAILURE;
   OMS_TRY()
     // Create a new one.
     onvif_media_signing_authenticity_t *auth_report = authenticity_report_create();
     OMS_THROW_IF(auth_report == NULL, OMS_MEMORY);
-    // Transfer |product_info| from |self|.
-    OMS_THROW(transfer_vendor_info(&auth_report->product_info, self->product_info));
+    // Transfer |vendor_info| from |self|.
+    transfer_vendor_info(&auth_report->vendor_info, &self->vendor_info);
 
     self->authenticity = auth_report;
     set_authenticity_shortcuts(self);
@@ -391,7 +394,6 @@ create_local_authenticity_report_if_needed(onvif_media_signing_t *self)
 
   return status;
 }
-#endif
 
 static onvif_media_signing_authenticity_t *
 authenticity_report_create()

--- a/lib/src/oms_authenticity_report.h
+++ b/lib/src/oms_authenticity_report.h
@@ -30,7 +30,7 @@
 
 // #include "includes/onvif_media_signing_common.h"
 #include "includes/onvif_media_signing_validator.h"
-// #include "signed_video_defines.h"  // svrc_t
+#include "oms_defines.h"  // oms_rc
 // #include "signed_video_internal.h"
 
 #if 0
@@ -66,20 +66,20 @@ latest_validation_init(onvif_media_signing_latest_validation_t *self);
 void
 accumulated_validation_init(onvif_media_signing_accumulated_validation_t *self);
 
-#if 0
 /**
  * @brief Maybe creates a local authenticity report
  *
- * If an authenticity report has not been set by the user, a local one is created to populate for
- * later use.
+ * If an authenticity report has not been set by the user, a local one is created to
+ * populate for later use.
  *
- * @param self The current Signed Video session
+ * @param self The current Media Signing session
  *
- * @returns A Signed Video Return Code
+ * @returns A Media Signing Return Code
  */
-svrc_t
-create_local_authenticity_report_if_needed(signed_video_t *self);
+oms_rc
+create_local_authenticity_report_if_needed(onvif_media_signing_t *self);
 
+#if 0
 /**
  * @brief Copies a null-terminated string
  *

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -217,6 +217,9 @@ struct _onvif_media_signing_t {
 
   // Members only used for validation
 
+  // TODO: Collect everything needed by the authentication part only in one struct/object,
+  // which then is not needed to be created on the signing side, saving some memory.
+
   // Shortcuts to authenticity information.
   // If no authenticity report has been set by the user the memory is allocated and used
   // locally. Otherwise, these members point to the corresponding members in
@@ -225,17 +228,17 @@ struct _onvif_media_signing_t {
   onvif_media_signing_accumulated_validation_t *accumulated_validation;
   onvif_media_signing_authenticity_t *authenticity;  // Pointer to the authenticity report
                                                      // of which results will be written.
-#ifdef VALIDATION_SIDE
-  // Members only used for validation
-  // TODO: Collect everything needed by the authentication part only in one struct/object,
-  // which then is not needed to be created on the signing side, saving some memory.
-
   // Status and authentication
   // Linked list to track the validation status of each added NAL Unit. Items are appended
   // to the list when added, that is, in onvif_media_signing_add_nalu_and_authenticate().
   // Items are removed when reported through the authenticity_report.
-  h26x_nalu_list_t *nalu_list;
+  // nalu_info_list_t *nalu_list;
   bool authentication_started;
+
+#ifdef VALIDATION_SIDE
+  // Members only used for validation
+  // TODO: Collect everything needed by the authentication part only in one struct/object,
+  // which then is not needed to be created on the signing side, saving some memory.
 
   validation_flags_t validation_flags;
   gop_state_t gop_state;

--- a/lib/src/oms_tmp_definitions.c
+++ b/lib/src/oms_tmp_definitions.c
@@ -25,23 +25,12 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ************************************************************************************/
 
-#include <stdint.h>  // uint8_t
 #include <stdlib.h>  // size_t
 
 #include "includes/onvif_media_signing_common.h"  // MediaSigningReturnCode, onvif_media_signing_t
 #include "includes/onvif_media_signing_validator.h"  // onvif_media_signing_authenticity_t
 
 /* onvif_media_signing_validator APIs */
-MediaSigningReturnCode
-onvif_media_signing_add_nalu_and_authenticate(onvif_media_signing_t *self,
-    const uint8_t *nalu,
-    size_t nalu_size,
-    onvif_media_signing_authenticity_t **authenticity)
-{
-  return (!self || !nalu || nalu_size == 0 || authenticity) ? OMS_INVALID_PARAMETER
-                                                            : OMS_OK;
-}
-
 MediaSigningReturnCode
 onvif_media_signing_set_root_certificate(onvif_media_signing_t *self,
     const char *root_cert,

--- a/lib/src/oms_validator.c
+++ b/lib/src/oms_validator.c
@@ -1,0 +1,1166 @@
+/************************************************************************************
+ * Copyright (c) 2024 ONVIF.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *    * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *    * Neither the name of ONVIF nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software
+ *      without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ONVIF BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ************************************************************************************/
+
+// #include <assert.h>  // assert
+// #include <stdlib.h>  // free
+
+#include "includes/onvif_media_signing_common.h"
+#include "includes/onvif_media_signing_validator.h"
+#include "oms_authenticity_report.h"  // create_local_authenticity_report_if_needed()
+#include "oms_defines.h"
+// #include "signed_video_h26x_internal.h"  // gop_state_*(), update_gop_hash(),
+// update_validation_flags() #include "signed_video_h26x_nalu_list.h"  //
+// h26x_nalu_list_append()
+#include "oms_internal.h"
+// #include "signed_video_openssl_internal.h"  // openssl_{verify_hash,
+// public_key_malloc}() #include "signed_video_tlv.h"  // tlv_find_tag()
+
+#if 0
+static oms_rc
+decode_sei_data(onvif_media_signing_t *signed_video, const uint8_t *payload, size_t payload_size);
+
+static bool
+verify_hashes_with_hash_list(onvif_media_signing_t *self,
+    int *num_expected_nalus,
+    int *num_received_nalus);
+static int
+set_validation_status_of_items_used_in_gop_hash(h26x_nalu_list_t *nalu_list,
+    char validation_status);
+static bool
+verify_hashes_with_gop_hash(onvif_media_signing_t *self, int *num_expected_nalus, int *num_received_nalus);
+static bool
+verify_hashes_without_sei(onvif_media_signing_t *self);
+static void
+validate_authenticity(onvif_media_signing_t *self);
+static oms_rc
+prepare_for_validation(onvif_media_signing_t *self);
+static bool
+is_recurrent_data_decoded(onvif_media_signing_t *self);
+static bool
+has_pending_gop(onvif_media_signing_t *self);
+static bool
+validation_is_feasible(const h26x_nalu_list_item_t *item);
+
+static void
+remove_used_in_gop_hash(h26x_nalu_list_t *nalu_list);
+static oms_rc
+compute_gop_hash(onvif_media_signing_t *self, h26x_nalu_list_item_t *sei);
+
+#ifdef SIGNED_VIDEO_DEBUG
+const char *kAuthResultValidStr[SV_AUTH_NUM_SIGNED_GOP_VALID_STATES] = {"SIGNATURE MISSING",
+    "SIGNATURE PRESENT", "NOT OK", "OK WITH MISSING INFO", "OK", "VERSION MISMATCH"};
+#endif
+
+/**
+ * The function is called when we receive a SEI NALU holding all the GOP information such as a
+ * signed hash. The payload is decoded and the signature hash is verified against the gop_hash in
+ * |signed_video|.
+ */
+static oms_rc
+decode_sei_data(onvif_media_signing_t *self, const uint8_t *payload, size_t payload_size)
+{
+  assert(self && payload && (payload_size > 0));
+  // Get the last GOP counter before updating.
+  uint32_t last_gop_number = self->gop_info->global_gop_counter;
+  uint32_t exp_gop_number = last_gop_number + 1;
+  DEBUG_LOG("SEI payload size = %zu, exp gop number = %u", payload_size, exp_gop_number);
+
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  OMS_TRY()
+    SV_THROW_WITH_MSG(tlv_decode(self, payload, payload_size), "Failed decoding SEI payload");
+
+    // Compare new with last number of GOPs to detect potentially lost SEIs.
+    uint32_t new_gop_number = self->gop_info->global_gop_counter;
+    int64_t potentially_missed_gops = (int64_t)new_gop_number - exp_gop_number;
+    // If number of |potentially_missed_gops| is negative, we have either lost SEIs together with a
+    // wraparound of |global_gop_counter|, or a reset of Signed Video was done on the camera. The
+    // correct number of lost SEIs is of less importance, since we only want to know IF we have lost
+    // any. Therefore, make sure we map the value into the positive side only. It is possible to
+    // signal to the validation side that a reset was done on the camera, but it is still not
+    // possible to validate pending NALUs.
+    if (potentially_missed_gops < 0) potentially_missed_gops += INT64_MAX;
+    // It is only possible to know if a SEI has been lost if the |global_gop_counter| is in sync.
+    // Otherwise, the counter cannot be trusted.
+    self->gop_state.has_lost_sei =
+        (potentially_missed_gops > 0) && self->gop_info->global_gop_counter_is_synced;
+    // Every SEI is associated with a GOP. If a lost SEI has been detected, and no GOP end has been
+    // found prior to this SEI, it means both a SEI and an I-frame was lost. This is defined as a
+    // lost GOP transition.
+    if (self->gop_state.no_gop_end_before_sei && self->gop_state.has_lost_sei) {
+      self->gop_state.gop_transition_is_lost = true;
+    }
+
+  OMS_CATCH()
+  OMS_DONE(status)
+
+  return status;
+}
+
+/* Verifies the hashes of the oldest pending GOP from a hash list.
+ *
+ * If the |document_hash| in the SEI is verified successfully with the signature and the Public key,
+ * the hash list is valid. By looping through the NALUs in the |nalu_list| we compare individual
+ * hashes with the ones in the hash list. Items are marked as OK ('.') if we can find its twin in
+ * correct order. Otherwise, they become NOT OK ('N').
+ *
+ * If we detect missing/lost NALUs, empty items marked 'M' are added.
+ *
+ * While verifying hashes the number of expected and received NALUs are computed. These can be
+ * output.
+ *
+ * Returns false if we failed verifying hashes. Otherwise, returns true. */
+static bool
+verify_hashes_with_hash_list(onvif_media_signing_t *self, int *num_expected_nalus, int *num_received_nalus)
+{
+  assert(self);
+
+  const size_t hash_size = self->verify_data->hash_size;
+  assert(hash_size > 0);
+  // Expected hashes.
+  uint8_t *expected_hashes = self->gop_info->hash_list;
+  const int num_expected_hashes = self->gop_info->list_idx / hash_size;
+
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+  h26x_nalu_list_item_t *last_used_item = NULL;
+
+  if (!expected_hashes || !nalu_list) return false;
+
+  h26x_nalu_list_print(nalu_list);
+
+  // Get the SEI associated with the oldest pending GOP.
+  h26x_nalu_list_item_t *sei = h26x_nalu_list_get_next_sei_item(nalu_list);
+  // TODO: Investigate if we can end up without finding a SEI. If so, should we fail the validation
+  // or call verify_hashes_without_sei()?
+  if (!sei) return false;
+
+  // First of all we need to know if the SEI itself is authentic, that is, the SEI |document_hash|
+  // has successfully been verified (= 1). If the document could not be verified sucessfully, that
+  // is, the SEI NALU is invalid, all NALUs become invalid. Hence, verify_hashes_without_sei().
+  switch (self->gop_info->verified_signature_hash) {
+    case -1:
+      sei->validation_status = 'E';
+      return verify_hashes_without_sei(self);
+    case 0:
+      sei->validation_status = 'N';
+      return verify_hashes_without_sei(self);
+    case 1:
+      assert(sei->validation_status == 'P');
+      break;
+    default:
+      // We should not end up here.
+      assert(false);
+      return false;
+  }
+
+  // The next step is to verify the hashes of the NALUs in the |nalu_list| until we hit a transition
+  // to the next GOP, but no further than to the item after the |sei|.
+
+  // Statistics tracked while verifying hashes.
+  int num_invalid_nalus_since_latest_match = 0;
+  int num_verified_hashes = 0;
+  // Initialization
+  int latest_match_idx = -1;  // The latest matching hash in |hash_list|
+  int compare_idx = 0;  // The offset in |hash_list| selecting the hash to compared
+                        // against the |hash_to_verify|
+  bool found_next_gop = false;
+  bool found_item_after_sei = false;
+  h26x_nalu_list_item_t *item = nalu_list->first_item;
+  // This while-loop selects items from the oldest pending GOP. Each item hash is then verified
+  // against the feasible hashes in the received |hash_list|.
+  while (item && !(found_next_gop || found_item_after_sei)) {
+    // If this item is not Pending, move to the next one.
+    if (item->validation_status != 'P') {
+      DEBUG_LOG("Skipping non-pending NALU");
+      item = item->next;
+      continue;
+    }
+    // Only a missing item has a null pointer NALU, but they are skipped.
+    assert(item->nalu);
+    // Check if this is the item right after the |sei|.
+    found_item_after_sei = (item->prev == sei);
+    // Check if this |is_first_nalu_in_gop|, but not used before.
+    found_next_gop = (item->nalu->is_first_nalu_in_gop && !item->need_second_verification);
+    // If this is a SEI, it is not part of the hash list and should not be verified.
+    if (item->nalu->is_gop_sei) {
+      DEBUG_LOG("Skipping SEI");
+      item = item->next;
+      continue;
+    }
+
+    last_used_item = item;
+    num_verified_hashes++;
+
+    // Fetch the |hash_to_verify|, which normally is the item->hash, but if this is NALU has been
+    // used in a previous verification we use item->second_hash.
+    uint8_t *hash_to_verify = item->need_second_verification ? item->second_hash : item->hash;
+
+    // Compare |hash_to_verify| against all the |expected_hashes| since the |latest_match_idx|. Stop
+    // when we get a match or reach the end.
+    compare_idx = latest_match_idx + 1;
+    // This while-loop searches for a match among the feasible hashes in |hash_list|.
+    while (compare_idx < num_expected_hashes) {
+      uint8_t *expected_hash = &expected_hashes[compare_idx * hash_size];
+
+      if (memcmp(hash_to_verify, expected_hash, hash_size) == 0) {
+        // We have a match. Set validation_status and add missing nalus if we have detected any.
+        if (item->second_hash && !item->need_second_verification &&
+            item->nalu->is_first_nalu_in_gop) {
+          // If this |is_first_nalu_in_gop| it should be verified twice. If this the first time we
+          // signal that we |need_second_verification|.
+          DEBUG_LOG("This NALU needs a second verification");
+          item->need_second_verification = true;
+        } else {
+          item->validation_status = item->first_verification_not_authentic ? 'N' : '.';
+          item->need_second_verification = false;
+        }
+        // Add missing items to |nalu_list|.
+        int num_detected_missing_nalus =
+            (compare_idx - latest_match_idx) - 1 - num_invalid_nalus_since_latest_match;
+        // No need to check the return value. A failure only affects the statistics. In the worst
+        // case we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
+        h26x_nalu_list_add_missing(nalu_list, num_detected_missing_nalus, false, item);
+        // Reset counters and latest_match_idx.
+        latest_match_idx = compare_idx;
+        num_invalid_nalus_since_latest_match = 0;
+        break;
+      }
+      compare_idx++;
+    }  // Done comparing feasible hashes.
+
+    // Handle the non-match case.
+    if (latest_match_idx != compare_idx) {
+      // We have compared against all feasible hashes in |hash_list| without a match. Mark as NOT
+      // OK, or keep pending for second use.
+      if (item->second_hash && !item->need_second_verification) {
+        item->need_second_verification = true;
+        // If this item will be used in a second verification the flag
+        // |first_verification_not_authentic| is set.
+        item->first_verification_not_authentic = true;
+      } else {
+        // Reset |need_second_verification|.
+        item->need_second_verification = false;
+        item->validation_status = 'N';
+      }
+      // Update counters.
+      num_invalid_nalus_since_latest_match++;
+    }
+    item = item->next;
+  }  // Done looping through pending GOP.
+
+  // Check if we had no matches at all. See if we should fill in with missing NALUs. This is of less
+  // importance since the GOP is not authentic, but if we can we should provide proper statistics.
+  if (latest_match_idx == -1) {
+    DEBUG_LOG("Never found a matching hash at all");
+    int num_missing_nalus = num_expected_hashes - num_invalid_nalus_since_latest_match;
+    // We do not know where in the sequence of NALUs they were lost. Simply add them before the
+    // first item. If the first item needs a second opinion, that is, it has already been verified
+    // once, we append that item. Otherwise, prepend it with missing items.
+    const bool append =
+        nalu_list->first_item->second_hash && !nalu_list->first_item->need_second_verification;
+    // No need to check the return value. A failure only affects the statistics. In the worst case
+    // we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
+    h26x_nalu_list_add_missing(nalu_list, num_missing_nalus, append, nalu_list->first_item);
+  }
+
+  // If the last invalid NALU is the first NALU in a GOP or the NALU after the SEI, keep it
+  // pending. If the last NALU is valid and there are more expected hashes we either never
+  // verified any hashes or we have missing NALUs.
+  if (last_used_item) {
+    if (latest_match_idx != compare_idx) {
+      // Last verified hash is invalid.
+      last_used_item->first_verification_not_authentic = true;
+      // Give this NALU a second verification because it could be that it is present in the next GOP
+      // and brought in here due to some lost NALUs.
+      last_used_item->need_second_verification = true;
+    } else {
+      // Last received hash is valid. Check if there are unused hashes in |hash_list|. Note that the
+      // index of the hashes span from 0 to |num_expected_hashes| - 1, so if |latest_match_idx| =
+      // |num_expected_hashes| - 1, we have no pending nalus.
+      int num_unused_expected_hashes = num_expected_hashes - 1 - latest_match_idx;
+      // We cannot mark the last item as Missing since it will be handled a second time in the next
+      // GOP.
+      num_unused_expected_hashes--;
+      if (num_unused_expected_hashes >= 0) {
+        // Avoids reporting the lost linked hash twice.
+        num_verified_hashes++;
+      }
+      // No need to check the return value. A failure only affects the statistics. In the worst case
+      // we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
+      h26x_nalu_list_add_missing(nalu_list, num_unused_expected_hashes, true, last_used_item);
+    }
+  }
+
+  // Done with the SEI. Mark as valid, because if we failed verifying the |document_hash| we would
+  // not be here.
+  sei->validation_status = '.';
+
+  if (num_expected_nalus) *num_expected_nalus = num_expected_hashes;
+  if (num_received_nalus) *num_received_nalus = num_verified_hashes;
+
+  return true;
+}
+
+/* Sets the |validation_status| of all items in |nalu_list| that are |used_in_gop_hash|.
+ *
+ * Returns the number of items marked and -1 upon failure. */
+static int
+set_validation_status_of_items_used_in_gop_hash(h26x_nalu_list_t *nalu_list, char validation_status)
+{
+  if (!nalu_list) return -1;
+
+  int num_marked_items = 0;
+
+  // Loop through the |nalu_list| and set the |validation_status| if the item is |used_in_gop_hash|
+  h26x_nalu_list_item_t *item = nalu_list->first_item;
+  while (item) {
+    if (item->used_in_gop_hash) {
+      // Items used in two verifications should not have |validation_status| set until it has been
+      // used twice. If this is the first time we set the flag |first_verification_not_authentic|.
+      if (item->second_hash && !item->need_second_verification) {
+        DEBUG_LOG("This NALU needs a second verification");
+        item->need_second_verification = true;
+        item->first_verification_not_authentic = (validation_status != '.') ? true : false;
+      } else {
+        item->validation_status = item->first_verification_not_authentic ? 'N' : validation_status;
+        item->need_second_verification = false;
+        num_marked_items++;
+      }
+    }
+
+    item->used_in_gop_hash = false;
+    item = item->next;
+  }
+
+  return num_marked_items;
+}
+
+/* Verifies the hashes of the oldest pending GOP from a gop_hash.
+ *
+ * Since the gop_hash is one single hash representing the entire GOP we mark all of them as OK ('.')
+ * if we can verify the gop_hash with the signature and Public key. Otherwise, they all become NOT
+ * OK ('N').
+ *
+ * If we detect missing/lost NALUs, empty items marked 'M' are added.
+ *
+ * While verifying hashes the number of expected and received NALUs are computed. These can be
+ * output.
+ *
+ * Returns false if we failed verifying hashes. Otherwise, returns true. */
+static bool
+verify_hashes_with_gop_hash(onvif_media_signing_t *self, int *num_expected_nalus, int *num_received_nalus)
+{
+  assert(self);
+
+  // Initialize to "Unknown"
+  int num_expected_hashes = -1;
+  int num_received_hashes = -1;
+  char validation_status = 'P';
+
+  // The verification of the gop_hash (|verified_signature_hash|) determines the |validation_status|
+  // of the entire GOP.
+  switch (self->gop_info->verified_signature_hash) {
+    case 1:
+      validation_status = '.';
+      break;
+    case 0:
+      validation_status = 'N';
+      break;
+    case -1:
+    default:
+      // Got an error when verifying the gop_hash. Verify without a SEI.
+      validation_status = 'E';
+      return verify_hashes_without_sei(self);
+  }
+
+  // TODO: Investigate if we have a flaw in the ability to detect missing NALUs. Note that we can
+  // only trust the information in the SEI if the |document_hash| (of the SEI) can successfully be
+  // verified. This is only feasible if we have NOT lost any NALUs, hence we have a Catch 22
+  // situation and can never add any missing NALUs.
+
+  // The number of hashes part of the gop_hash was transmitted in the SEI.
+  num_expected_hashes = (int)self->gop_info->num_sent_nalus;
+
+  // Identify the first NALU used in the gop_hash. This will be used to add missing NALUs.
+  h26x_nalu_list_item_t *first_gop_hash_item = self->nalu_list->first_item;
+  while (first_gop_hash_item && !first_gop_hash_item->used_in_gop_hash) {
+    first_gop_hash_item = first_gop_hash_item->next;
+  }
+  num_received_hashes =
+      set_validation_status_of_items_used_in_gop_hash(self->nalu_list, validation_status);
+
+  if (!self->validation_flags.is_first_validation && first_gop_hash_item) {
+    int num_missing_nalus = num_expected_hashes - num_received_hashes;
+    const bool append = first_gop_hash_item->nalu->is_first_nalu_in_gop;
+    // No need to check the return value. A failure only affects the statistics. In the worst case
+    // we may signal SV_AUTH_RESULT_OK instead of SV_AUTH_RESULT_OK_WITH_MISSING_INFO.
+    h26x_nalu_list_add_missing(self->nalu_list, num_missing_nalus, append, first_gop_hash_item);
+  }
+
+  if (num_expected_nalus) *num_expected_nalus = num_expected_hashes;
+  if (num_received_nalus) *num_received_nalus = num_received_hashes;
+
+  return true;
+}
+
+/* Verifying hashes without the SEI means that we have nothing to verify against. Therefore, we mark
+ * all NALUs of the oldest pending GOP with |validation_status| = 'N'. This function is used both
+ * for unsigned videos as well as when the SEI has been modified or lost.
+ *
+ * Returns false if we failed verifying hashes, which happens if there is no list or if there are no
+ * pending NALUs. Otherwise, returns true. */
+static bool
+verify_hashes_without_sei(onvif_media_signing_t *self)
+{
+  assert(self);
+
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+
+  if (!nalu_list) return false;
+
+  h26x_nalu_list_print(nalu_list);
+
+  // Start from the oldest item and mark all pending items as NOT OK ('N') until we detect a new GOP
+  int num_marked_items = 0;
+  h26x_nalu_list_item_t *item = nalu_list->first_item;
+  bool found_next_gop = false;
+  while (item && !found_next_gop) {
+    // Skip non-pending items.
+    if (item->validation_status != 'P') {
+      item = item->next;
+      continue;
+    }
+
+    // A new GOP starts if the NALU |is_first_nalu_in_gop|. Such a NALU is hashed twice; as an
+    // initial hash AND as a linking hash between GOPs. If this is the first time is is used in
+    // verification it also marks the start of a new GOP.
+    found_next_gop = item->nalu->is_first_nalu_in_gop && !item->need_second_verification;
+
+    // Mark the item as 'Not Authentic' or keep it for a second verification.
+    if (found_next_gop) {
+      // Keep the item pending and mark the first verification as not authentic.
+      item->need_second_verification = true;
+      item->first_verification_not_authentic = true;
+    } else if (item->validation_status == 'P') {
+      item->need_second_verification = false;
+      item->validation_status = 'N';
+      num_marked_items++;
+    }
+    item = item->next;
+  }
+
+  // If we have verified a GOP without a SEI, we should increment the |global_gop_counter|.
+  if (self->validation_flags.signing_present && (num_marked_items > 0)) {
+    self->gop_info->global_gop_counter++;
+  }
+
+  return found_next_gop;
+}
+
+/* Validates the authenticity using hashes in the |nalu_list|.
+ *
+ * In brief, the validation verifies hashes and sets the |validation_status| given the outcome.
+ * Verifying a hash means comparing two and check if they are identical. There are three ways to
+ * verify hashes
+ * 1) verify_hashes_without_sei(): There is no SEI available, hence no expected hash to compare
+ *    exists. All the hashes we know cannot be verified are then marked as 'N'.
+ * 2) verify_hashes_from_gop_hash(): A hash representing all hashes of a GOP (a gop_hash) is
+ *    generated. If this gop_hash verifies successful against the signature all hashes are correct
+ *    and each item, included in the gop_hash, are marked as '.'. If the verification fails we mark
+ *    all as 'N'.
+ * 3) verify_hashes_from_hash_list(): We have access to all transmitted hashes and can verify each
+ *    and one of them against the received ones, and further, mark them correspondingly.
+ *
+ * If we during verification detect missing NALUs, we add empty items (marked 'M') to the
+ * |nalu_list|.
+ *
+ * - After verification, hence the |validation_status| of each item in the list has been updated,
+ *   statistics are collected from the list, using h26x_nalu_list_get_stats().
+ * - Based on the statistics a validation decision can be made.
+ * - Update |latest_validation| with the validation result.
+ */
+static void
+validate_authenticity(onvif_media_signing_t *self)
+{
+  assert(self);
+
+  gop_state_t *gop_state = &(self->gop_state);
+  validation_flags_t *validation_flags = &(self->validation_flags);
+  signed_video_latest_validation_t *latest = self->latest_validation;
+
+  SignedVideoAuthenticityResult valid = SV_AUTH_RESULT_NOT_OK;
+  // Initialize to "Unknown"
+  int num_expected_nalus = -1;
+  int num_received_nalus = -1;
+  int num_invalid_nalus = -1;
+  int num_missed_nalus = -1;
+  bool verify_success = false;
+
+  if (gop_state->has_lost_sei && !gop_state->gop_transition_is_lost) {
+    DEBUG_LOG("We never received the SEI associated with this GOP");
+    // We never received the SEI nalu, but we know we have passed a GOP transition. Hence, we cannot
+    // verify this GOP. Marking this GOP as not OK by verify_hashes_without_sei().
+    remove_used_in_gop_hash(self->nalu_list);
+    verify_success = verify_hashes_without_sei(self);
+  } else {
+    if (self->gop_info->signature_hash_type == DOCUMENT_HASH) {
+      verify_success = verify_hashes_with_hash_list(self, &num_expected_nalus, &num_received_nalus);
+    } else {
+      verify_success = verify_hashes_with_gop_hash(self, &num_expected_nalus, &num_received_nalus);
+    }
+  }
+
+  // Collect statistics from the nalu_list. This is used to validate the GOP and provide additional
+  // information to the user.
+  bool has_valid_nalus =
+      h26x_nalu_list_get_stats(self->nalu_list, &num_invalid_nalus, &num_missed_nalus);
+  DEBUG_LOG("Number of invalid NALUs = %d.", num_invalid_nalus);
+  DEBUG_LOG("Number of missed NALUs = %d.", num_missed_nalus);
+
+  valid = (num_invalid_nalus > 0) ? SV_AUTH_RESULT_NOT_OK : SV_AUTH_RESULT_OK;
+
+  // Post-validation actions.
+
+  // If we lose an entire GOP (part from the associated SEI) it will be seen as valid. Here we fix
+  // it afterwards.
+  // TODO: Move this inside the verify_hashes_ functions. We should not need to perform any special
+  // actions on the output.
+  if (!validation_flags->is_first_validation) {
+    if ((valid == SV_AUTH_RESULT_OK) && (num_expected_nalus > 1) &&
+        (num_missed_nalus >= num_expected_nalus - 1)) {
+      valid = SV_AUTH_RESULT_NOT_OK;
+    }
+    self->gop_info->global_gop_counter_is_synced = true;
+  }
+  // Determine if this GOP is valid, but has missing information. This happens if we have detected
+  // missed NALUs or if the GOP is incomplete.
+  if (valid == SV_AUTH_RESULT_OK && (num_missed_nalus > 0 && verify_success)) {
+    valid = SV_AUTH_RESULT_OK_WITH_MISSING_INFO;
+    DEBUG_LOG("Successful validation, but detected missing NALUs");
+  }
+  // The very first validation needs to be handled separately. If this is truly the start of a
+  // stream we have all necessary information to successfully validate the authenticity. It can be
+  // interpreted as being in sync with its signing counterpart. If this session validates the
+  // authenticity of a segment of a stream, e.g., an exported file, we start out of sync. The first
+  // SEI may be associated with a GOP prior to this segment.
+  if (validation_flags->is_first_validation) {
+    // Change status from SV_AUTH_RESULT_OK to SV_AUTH_RESULT_SIGNATURE_PRESENT if no valid NALUs
+    // were found when collecting stats.
+    if ((valid == SV_AUTH_RESULT_OK) && !has_valid_nalus) {
+      valid = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+    }
+    // If validation was successful, the |global_gop_counter| is in sync.
+    self->gop_info->global_gop_counter_is_synced = (valid == SV_AUTH_RESULT_OK);
+    if (valid != SV_AUTH_RESULT_OK) {
+      // We have validated the authenticity based on one single NALU, but failed. A success can only
+      // happen if we are at the beginning of the original stream. For all other cases, for example,
+      // if we validate the authenticity of an exported file, the first SEI may be associated with a
+      // part of the original stream not present in the file. Hence, mark as
+      // SV_AUTH_RESULT_SIGNATURE_PRESENT instead.
+      DEBUG_LOG("This first validation cannot be performed");
+      // Since we verify the linking hash twice we need to remove the set
+      // |first_verification_not_authentic|. Otherwise, the false failure leaks into the next GOP.
+      // Further, empty items marked 'M', may have been added at the beginning. These have no
+      // meaning and may only confuse the user. These should be removed. This is handled in
+      // h26x_nalu_list_remove_missing_items().
+      h26x_nalu_list_remove_missing_items(self->nalu_list);
+      valid = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+      num_expected_nalus = -1;
+      num_received_nalus = -1;
+      // If validation was tried with the very first SEI in stream it cannot be part at.
+      // Reset the first validation to be able to validate a segment in the middle of the stream.
+      self->validation_flags.reset_first_validation = (self->gop_info->num_sent_nalus == 1);
+    }
+  }
+  if (latest->public_key_has_changed) valid = SV_AUTH_RESULT_NOT_OK;
+
+  // Update |latest_validation| with the validation result.
+  latest->authenticity = valid;
+  latest->number_of_expected_picture_nalus = num_expected_nalus;
+  latest->number_of_received_picture_nalus = num_received_nalus;
+}
+
+/* Removes the |used_in_gop_hash| flag from all items. */
+static void
+remove_used_in_gop_hash(h26x_nalu_list_t *nalu_list)
+{
+  if (!nalu_list) return;
+
+  h26x_nalu_list_item_t *item = nalu_list->first_item;
+  while (item) {
+    item->used_in_gop_hash = false;
+    item = item->next;
+  }
+}
+
+/* Computes the gop_hash of the oldest pending GOP in the nalu_list and completes the recursive
+ * operation with the hash of the |sei|. */
+static oms_rc
+compute_gop_hash(onvif_media_signing_t *self, h26x_nalu_list_item_t *sei)
+{
+  assert(self);
+
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+
+  // We expect a valid SEI and that it has been decoded.
+  if (!(sei && sei->has_been_decoded)) return OMS_INVALID_PARAMETER;
+  if (!nalu_list) return OMS_INVALID_PARAMETER;
+
+  const size_t hash_size = self->verify_data->hash_size;
+  h26x_nalu_list_item_t *item = NULL;
+  gop_info_t *gop_info = self->gop_info;
+  uint8_t *nalu_hash = gop_info->nalu_hash;
+
+  h26x_nalu_list_print(nalu_list);
+
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  OMS_TRY()
+    // Initialize the gop_hash by resetting it.
+    OMS_THROW(reset_gop_hash(self));
+    // In general we do not know when the SEI, associated with a GOP, arrives. If it is delayed we
+    // should collect all NALUs of the GOP, that is, stop adding hashes when we find a new GOP. If
+    // the SEI is not delayed we need also the NALU right after the SEI to complete the operation.
+
+    // Loop through the items of |nalu_list| until we find a new GOP. If no new GOP is found until
+    // we reach the SEI we stop at the NALU right after the SEI. Update the gop_hash with each NALU
+    // hash and finalize the operation by updating with the hash of the SEI.
+    uint8_t *hash_to_add = NULL;
+    bool found_next_gop = false;
+    bool found_item_after_sei = false;
+    item = nalu_list->first_item;
+    while (item && !(found_next_gop || found_item_after_sei)) {
+      // If this item is not Pending, move to the next one.
+      if (item->validation_status != 'P') {
+        item = item->next;
+        continue;
+      }
+      // Only missing items can have a null pointer |nalu|, but they are not pending.
+      assert(item->nalu);
+      // Check if this is the item after the |sei|.
+      found_item_after_sei = (item->prev == sei);
+      // Check if this |is_first_nalu_in_gop|, but used in verification for the first time.
+      found_next_gop = (item->nalu->is_first_nalu_in_gop && !item->need_second_verification);
+      // If this is the SEI associated with the GOP, or any SEI, we skip it. The SEI hash will be
+      // added to |gop_hash| as the last hash.
+      if (item->nalu->is_gop_sei) {
+        item = item->next;
+        continue;
+      }
+
+      // Fetch the |hash_to_add|, which normally is the item->hash, but if the item has been used
+      // ones in verification we use the |second_hash|.
+      hash_to_add = item->need_second_verification ? item->second_hash : item->hash;
+      // Copy to the |nalu_hash| slot in the memory and update the gop_hash.
+      memcpy(nalu_hash, hash_to_add, hash_size);
+      OMS_THROW(update_gop_hash(self->crypto_handle, gop_info));
+
+      // Mark the item and move to next.
+      item->used_in_gop_hash = true;
+      item = item->next;
+    }
+
+    // Complete the gop_hash with the hash of the SEI.
+    memcpy(nalu_hash, sei->hash, hash_size);
+    OMS_THROW(update_gop_hash(self->crypto_handle, gop_info));
+    sei->used_in_gop_hash = true;
+
+  OMS_CATCH()
+  {
+    // Failed computing the gop_hash. Remove all used_in_gop_hash markers.
+    remove_used_in_gop_hash(nalu_list);
+  }
+  OMS_DONE(status)
+
+  return status;
+}
+
+/* prepare_for_validation()
+ *
+ * 1) finds the oldest available and pending SEI in the |nalu_list|.
+ * 2) decodes the TLV data from it if it has not been done already.
+ * 3) points signature->hash to the location of either the document hash or the gop_hash. This is
+ *    needed to know which hash the signature will verify.
+ * 4) computes the gop_hash from hashes in the list, if we perform GOP level authentication.
+ * 5) verify the associated hash using the signature.
+ */
+static oms_rc
+prepare_for_validation(onvif_media_signing_t *self)
+{
+  assert(self);
+
+  validation_flags_t *validation_flags = &(self->validation_flags);
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+  sign_or_verify_data_t *verify_data = self->verify_data;
+  const size_t hash_size = verify_data->hash_size;
+
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  OMS_TRY()
+    h26x_nalu_list_item_t *sei = h26x_nalu_list_get_next_sei_item(nalu_list);
+    if (sei && !sei->has_been_decoded) {
+      // Decode the SEI and set signature->hash
+      const uint8_t *tlv_data = sei->nalu->tlv_data;
+      size_t tlv_size = sei->nalu->tlv_size;
+
+      OMS_THROW(decode_sei_data(self, tlv_data, tlv_size));
+      sei->has_been_decoded = true;
+      if (self->gop_info->signature_hash_type == DOCUMENT_HASH) {
+        memcpy(verify_data->hash, sei->hash, hash_size);
+      }
+    }
+    // Check if we should compute the gop_hash.
+    if (sei && sei->has_been_decoded && !sei->used_in_gop_hash &&
+        self->gop_info->signature_hash_type == GOP_HASH) {
+      OMS_THROW(compute_gop_hash(self, sei));
+      // TODO: Is it possible to avoid a memcpy by using a pointer strategy?
+      memcpy(verify_data->hash, self->gop_info->gop_hash, hash_size);
+    }
+
+    SV_THROW_IF_WITH_MSG(validation_flags->signing_present && !self->has_public_key,
+        SV_NOT_SUPPORTED, "No public key present");
+
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+    // If "Axis Communications AB" can be identified from the |product_info|, get
+    // |supplemental_authenticity| from |vendor_handle|.
+    if (strcmp(self->product_info.manufacturer, "Axis Communications AB") == 0) {
+
+      sv_vendor_axis_supplemental_authenticity_t *supplemental_authenticity = NULL;
+      OMS_THROW(get_axis_communications_supplemental_authenticity(
+          self->vendor_handle, &supplemental_authenticity));
+      if (strcmp(self->product_info.serial_number, supplemental_authenticity->serial_number)) {
+        self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_OK;
+      } else {
+        // Convert to SignedVideoPublicKeyValidation
+        switch (supplemental_authenticity->public_key_validation) {
+          case 1:
+            self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_OK;
+            break;
+          case 0:
+            self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_OK;
+            break;
+          case -1:
+          default:
+            self->latest_validation->public_key_validation = SV_PUBKEY_VALIDATION_NOT_FEASIBLE;
+            break;
+        }
+      }
+    }
+#endif
+
+    // If we have received a SEI there is a signature to use for verification.
+    if (self->gop_state.has_sei || self->nalu_list->first_item->nalu->is_golden_sei) {
+#ifdef SIGNED_VIDEO_DEBUG
+      printf("Hash to verify against signature:\n");
+      for (size_t i = 0; i < verify_data->hash_size; i++) {
+        printf("%02x", verify_data->hash[i]);
+      }
+      printf("\n");
+#endif
+      OMS_THROW(openssl_verify_hash(verify_data, &self->gop_info->verified_signature_hash));
+    }
+
+  OMS_CATCH()
+  OMS_DONE(status)
+
+  return status;
+}
+
+// If public_key is not received then try to decode all recurrent tags.
+static bool
+is_recurrent_data_decoded(onvif_media_signing_t *self)
+{
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+
+  if (self->has_public_key || !self->validation_flags.signing_present) return true;
+
+  bool recurrent_data_decoded = false;
+  h26x_nalu_list_item_t *item = nalu_list->first_item;
+
+  while (item && !recurrent_data_decoded) {
+    if (item->nalu && item->nalu->is_gop_sei && item->validation_status == 'P') {
+      const uint8_t *tlv_data = item->nalu->tlv_data;
+      size_t tlv_size = item->nalu->tlv_size;
+      recurrent_data_decoded = tlv_find_and_decode_optional_tags(self, tlv_data, tlv_size);
+    }
+    item = item->next;
+  }
+
+  return recurrent_data_decoded;
+}
+
+/* Loops through the |nalu_list| to find out if there are GOPs that awaits validation. */
+static bool
+has_pending_gop(onvif_media_signing_t *self)
+{
+  assert(self && self->nalu_list);
+  gop_state_t *gop_state = &(self->gop_state);
+  h26x_nalu_list_item_t *item = self->nalu_list->first_item;
+  h26x_nalu_list_item_t *last_hashable_item = NULL;
+  // Statistics collected while looping through the NALUs.
+  int num_pending_gop_ends = 0;
+  bool found_pending_gop_sei = false;
+  bool found_pending_nalu_after_gop_sei = false;
+  bool found_pending_gop = false;
+
+  // Reset the |gop_state| members before running through the NALUs in |nalu_list|.
+  gop_state_reset(gop_state);
+
+  while (item && !found_pending_gop) {
+    gop_state_update(gop_state, item->nalu);
+    // Collect statistics from pending and hashable NALUs only. The others are either out of date or
+    // not part of the validation.
+    if (item->validation_status == 'P' && item->nalu && item->nalu->is_hashable) {
+      num_pending_gop_ends += (item->nalu->is_first_nalu_in_gop && !item->need_second_verification);
+      found_pending_gop_sei |= item->nalu->is_gop_sei;
+      found_pending_nalu_after_gop_sei |=
+          last_hashable_item && last_hashable_item->nalu->is_gop_sei;
+      last_hashable_item = item;
+    }
+    if (!self->validation_flags.signing_present) {
+      // If the video is not signed we need at least 2 I-frames to have a complete GOP.
+      found_pending_gop |= (num_pending_gop_ends >= 2);
+    } else {
+      // When the video is signed it is time to validate when there is at least one GOP and a SEI.
+      found_pending_gop |= (num_pending_gop_ends > 0) && found_pending_gop_sei;
+    }
+    // When a SEI is detected there can at most be one more NALU to perform validation.
+    found_pending_gop |= found_pending_nalu_after_gop_sei;
+    item = item->next;
+  }
+
+  if (!found_pending_gop && last_hashable_item && last_hashable_item->nalu->is_gop_sei) {
+    gop_state->validate_after_next_nalu = true;
+  }
+  gop_state->no_gop_end_before_sei = found_pending_nalu_after_gop_sei && (num_pending_gop_ends < 2);
+
+  return found_pending_gop;
+}
+
+/* Determines if the |item| is up for a validation.
+ * The NALU should be hashable and pending validation.
+ * If so, validation is triggered on any of the below
+ *   - a SEI (since if the SEI arrives late, the SEI is the final piece for validation)
+ *   - a new I-frame (since this marks the end of a GOP)
+ *   - the first hashable NALU right after a pending SEI (if a SEI has not been validated, we need
+ *     at most one more hashable NALU) */
+static bool
+validation_is_feasible(const h26x_nalu_list_item_t *item)
+{
+  if (!item->nalu) return false;
+  if (!item->nalu->is_hashable) return false;
+  if (item->validation_status != 'P') return false;
+
+  // Validation may be done upon a SEI.
+  if (item->nalu->is_gop_sei) return true;
+  // Validation may be done upon the end of a GOP.
+  if (item->nalu->is_first_nalu_in_gop && !item->need_second_verification) return true;
+  // Validation may be done upon a hashable NALU right after a SEI. This happens when the SEI was
+  // generated and attached to the same NALU that triggered the action.
+  item = item->prev;
+  while (item) {
+    if (item->nalu && item->nalu->is_hashable) {
+      break;
+    }
+    item = item->prev;
+  }
+  if (item && item->nalu->is_gop_sei && item->validation_status == 'P') return true;
+
+  return false;
+}
+
+/* Validates the authenticity of the video since last time if the state says so. After the
+ * validation the gop state is reset w.r.t. a new GOP. */
+static oms_rc
+maybe_validate_gop(onvif_media_signing_t *self, h26x_nalu_t *nalu)
+{
+  assert(self && nalu);
+
+  validation_flags_t *validation_flags = &(self->validation_flags);
+  signed_video_latest_validation_t *latest = self->latest_validation;
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+  bool validation_feasible = true;
+
+  // Make sure the current NALU can trigger a validation.
+  validation_feasible &= validation_is_feasible(nalu_list->last_item);
+  // Make sure there is enough information to perform validation.
+  validation_feasible &= is_recurrent_data_decoded(self);
+
+  // Abort if validation is not feasible.
+  if (!validation_feasible) {
+    // If this is the first arrived SEI, but could still not validate the authenticity, signal to
+    // the user that the Signed Video feature has been detected.
+    if (validation_flags->is_first_sei) {
+      latest->authenticity = SV_AUTH_RESULT_SIGNATURE_PRESENT;
+      latest->number_of_expected_picture_nalus = -1;
+      latest->number_of_received_picture_nalus = -1;
+      latest->number_of_pending_picture_nalus = h26x_nalu_list_num_pending_items(nalu_list);
+      latest->public_key_has_changed = false;
+      self->validation_flags.has_auth_result = true;
+    }
+    return SV_OK;
+  }
+
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  OMS_TRY()
+    // Keep validating as long as there are pending GOPs.
+    bool stop_validating = false;
+    while (has_pending_gop(self) && !stop_validating) {
+      // Initialize latest validation.
+      latest->authenticity = SV_AUTH_RESULT_NOT_OK;
+      latest->number_of_expected_picture_nalus = -1;
+      latest->number_of_received_picture_nalus = -1;
+      latest->number_of_pending_picture_nalus = -1;
+      latest->public_key_has_changed = false;
+
+      OMS_THROW(prepare_for_validation(self));
+
+      if (!validation_flags->signing_present) {
+        latest->authenticity = SV_AUTH_RESULT_NOT_SIGNED;
+        // Since no validation is performed (all items are kept pending) a forced stop is introduced
+        // to avoid a dead lock.
+        stop_validating = true;
+      } else {
+        validate_authenticity(self);
+      }
+
+      // The flag |is_first_validation| is used to ignore the first validation if we start the
+      // validation in the middle of a stream. Now it is time to reset it.
+      validation_flags->is_first_validation = !validation_flags->signing_present;
+
+      if (validation_flags->reset_first_validation) {
+        validation_flags->is_first_validation = true;
+        h26x_nalu_list_item_t *item = self->nalu_list->first_item;
+        while (item) {
+          if (item->nalu && item->nalu->is_first_nalu_in_gop) {
+            item->need_second_verification = false;
+            item->first_verification_not_authentic = false;
+            break;
+          }
+          item = item->next;
+        }
+      }
+      self->gop_info->verified_signature_hash = -1;
+      self->validation_flags.has_auth_result = true;
+
+      // All statistics but pending NALUs have already been collected.
+      latest->number_of_pending_picture_nalus = h26x_nalu_list_num_pending_items(nalu_list);
+
+      DEBUG_LOG("Validated GOP as %s", kAuthResultValidStr[latest->authenticity]);
+      DEBUG_LOG("Expected number of NALUs = %d", latest->number_of_expected_picture_nalus);
+      DEBUG_LOG("Received number of NALUs = %d", latest->number_of_received_picture_nalus);
+      DEBUG_LOG("Number of pending NALUs = %d", latest->number_of_pending_picture_nalus);
+    }
+
+  OMS_CATCH()
+  OMS_DONE(status)
+
+  return status;
+}
+
+/* This function updates the hashable part of the NALU data. The default assumption is that all
+ * bytes from NALU header to stop bit are hashed. This holds for all NALU types but the Signed Video
+ * generated SEI NALUs. For these, the last X bytes storing the signature are not hashed.
+ *
+ * In this function we update the h26x_nalu_t member |hashable_data_size| w.r.t. that. The pointer
+ * to the start is still the same. */
+void
+update_hashable_data(h26x_nalu_t *nalu)
+{
+  assert(nalu && (nalu->is_valid > 0));
+  if (!nalu->is_hashable || !nalu->is_gop_sei) return;
+
+  // This is a Signed Video generated NALU of type SEI. As payload it holds TLV data where the last
+  // chunk is supposed to be the signature. That part should not be hashed, hence we need to
+  // re-calculate hashable_data_size by subtracting the number of bytes (including potential
+  // emulation prevention bytes) coresponding to that tag. This is done by scanning the TLV for that
+  // tag.
+  const uint8_t *signature_tag_ptr =
+      tlv_find_tag(nalu->tlv_start_in_nalu_data, nalu->tlv_size, SIGNATURE_TAG, nalu->with_epb);
+
+  if (signature_tag_ptr) nalu->hashable_data_size = signature_tag_ptr - nalu->hashable_data;
+}
+
+/* A valid NALU is registered by hashing and adding to the |item|. */
+static oms_rc
+register_nalu(onvif_media_signing_t *self, h26x_nalu_list_item_t *item)
+{
+  h26x_nalu_t *nalu = item->nalu;
+  assert(self && nalu && nalu->is_valid >= 0);
+
+  if (nalu->is_valid == 0) return SV_OK;
+
+  update_hashable_data(nalu);
+  return hash_and_add_for_auth(self, item);
+}
+
+/* All NALUs in the |nalu_list| are re-registered by hashing them. */
+static oms_rc
+reregister_nalus(onvif_media_signing_t *self)
+{
+  assert(self);
+  assert(self->validation_flags.hash_algo_known);
+
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+  h26x_nalu_list_item_t *item = nalu_list->first_item;
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  while (item) {
+    if (item->nalu->is_valid <= 0) {
+      item = item->next;
+      continue;
+    }
+    status = hash_and_add_for_auth(self, item);
+    if (status != SV_OK) {
+      break;
+    }
+    item = item->next;
+  }
+
+  return status;
+}
+
+static void
+validate_golden_sei(onvif_media_signing_t *self, h26x_nalu_list_t *nalu_list)
+{
+  // TODO: Authenticity result will be overwritten in |maybe_validate_gop| API.
+  // It has to be fixed in a near future.
+
+  // Check the status of the verified signature hash for the GOP info.
+  switch (self->gop_info->verified_signature_hash) {
+    case 1:
+      nalu_list->first_item->validation_status = '.';
+      break;
+    case 0:
+      nalu_list->first_item->validation_status = 'N';
+      self->latest_validation->authenticity = SV_AUTH_RESULT_NOT_OK;
+      break;
+    case -1:
+    default:
+      // Got an error when verifying the gop_hash. Verify without a SEI.
+      nalu_list->first_item->validation_status = 'E';
+      self->latest_validation->authenticity = SV_AUTH_RESULT_NOT_OK;
+      self->has_public_key = false;
+  }
+}
+
+/* The basic order of actions are:
+ * 1. Every NALU should be parsed and added to the h26x_nalu_list (|nalu_list|).
+ * 2. Update validation flags given the added NALU.
+ * 3. Register NALU, in general that means hash the NALU if it is hashable and store it.
+ * 4. Validate a pending GOP if possible. */
+static oms_rc
+add_nalu_and_validate(onvif_media_signing_t *self, const uint8_t *nalu_data, size_t nalu_data_size)
+{
+  if (!self || !nalu_data || (nalu_data_size == 0)) return OMS_INVALID_PARAMETER;
+
+  h26x_nalu_list_t *nalu_list = self->nalu_list;
+  h26x_nalu_t nalu = parse_nalu_info(nalu_data, nalu_data_size, self->codec, true, true);
+  DEBUG_LOG("Received a %s of size %zu B", nalu_type_to_str(&nalu), nalu.nalu_data_size);
+  self->validation_flags.has_auth_result = false;
+
+  self->accumulated_validation->number_of_received_nalus++;
+
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  OMS_TRY()
+    // If there is no |nalu_list| we failed allocating memory for it.
+    SV_THROW_IF_WITH_MSG(
+        !nalu_list, SV_MEMORY, "No existing nalu_list. Cannot validate authenticity");
+    // Append the |nalu_list| with a new item holding a pointer to |nalu|. The |validation_status|
+    // is set accordingly.
+    OMS_THROW(h26x_nalu_list_append(nalu_list, &nalu));
+    SV_THROW_IF(nalu.is_valid < 0, OMS_UNKNOWN_FAILURE);
+    update_validation_flags(&self->validation_flags, &nalu);
+    OMS_THROW(register_nalu(self, nalu_list->last_item));
+    // As soon as the first Signed Video SEI arrives (|signing_present| is true) and the
+    // crypto TLV tag has been decoded it is feasible to hash the temporarily stored NAL
+    // Units.
+    if (!self->validation_flags.hash_algo_known && self->validation_flags.signing_present &&
+        is_recurrent_data_decoded(self)) {
+      if (!self->validation_flags.hash_algo_known) {
+        DEBUG_LOG("No cryptographic information found in SEI. Using default hash algo");
+        self->validation_flags.hash_algo_known = true;
+      }
+      // Note: This is a temporary solution.
+      // TODO: Handling of the golden SEI should be moved inside the |prepare_for_validation| API.
+      if (nalu.is_golden_sei) {
+        prepare_for_validation(self);
+        validate_golden_sei(self, nalu_list);
+      }
+
+      OMS_THROW(reregister_nalus(self));
+    }
+    OMS_THROW(maybe_validate_gop(self, &nalu));
+  OMS_CATCH()
+  OMS_DONE(status)
+
+  // Need to make a copy of the |nalu| independently of failure.
+  oms_rc copy_nalu_status =
+      h26x_nalu_list_copy_last_item(nalu_list, self->validation_flags.hash_algo_known);
+  // Make sure to return the first failure if both operations failed.
+  status = (status == SV_OK) ? copy_nalu_status : status;
+  if (status != SV_OK) nalu_list->last_item->validation_status = 'E';
+
+  free(nalu.nalu_data_wo_epb);
+
+  return status;
+}
+#endif
+
+MediaSigningReturnCode
+onvif_media_signing_add_nalu_and_authenticate(onvif_media_signing_t *self,
+    const uint8_t *nalu,
+    size_t nalu_size,
+    onvif_media_signing_authenticity_t **authenticity)
+{
+  if (!self || !nalu || nalu_size == 0) {
+    return OMS_INVALID_PARAMETER;
+  }
+
+  // TODO: Start on first successfully parsed NAL Unit?
+  self->authentication_started = true;
+
+  // If the user requests an authenticity report, initialize to NULL.
+  if (authenticity) {
+    *authenticity = NULL;
+  }
+
+  oms_rc status = OMS_UNKNOWN_FAILURE;
+  OMS_TRY()
+    OMS_THROW(create_local_authenticity_report_if_needed(self));
+    // TODO: Enable when implemented
+    // OMS_THROW(add_nalu_and_validate(self, nalu, nalu_size));
+
+    // if (self->validation_flags.has_auth_result) {
+    //   update_authenticity_report(self);
+    //   if (authenticity) {
+    //     *authenticity = onvif_media_signing_get_authenticity_report(self);
+    //   }
+    //   // Reset the timestamp for the next report.
+    //   self->latest_validation->has_timestamp = false;
+    // }
+  OMS_CATCH()
+  OMS_DONE(status)
+
+  return status;
+}

--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -46,6 +46,166 @@ teardown()
 {
 }
 
+#if 0
+/* Struct to accumulate validation results used to compare against expected values. */
+struct validation_stats {
+  int valid_gops;
+  int valid_gops_with_missing_info;
+  int invalid_gops;
+  int unsigned_gops;
+  int missed_nalus;
+  int pending_nalus;
+  int has_signature;
+  bool public_key_has_changed;
+  bool has_no_timestamp;
+  signed_video_accumulated_validation_t *final_validation;
+};
+
+/* validate_test_stream(...)
+ *
+ * Helper function to validate the authentication result.
+ * It takes a test stream |list| as input together with |expected| values of
+ *   valid gops
+ *   invalid gops
+ *   unsigned gops, that is gops without signature
+ *   missed number of gops
+ *   etc
+ *
+ * Note that the items in the |list| are consumed, that is, deleted after usage.
+ *
+ * If a NULL pointer |list| is passed in no action is taken.
+ * If a NULL pointer |sv| is passed in a new session is created. This is
+ * convenient if there are no other actions to take on |sv| outside this scope,
+ * like reset.
+ */
+static void
+validate_test_stream(signed_video_t *sv, test_stream_t *list, struct validation_stats expected)
+{
+  if (!list) return;
+
+  bool internal_sv = false;
+  if (!sv) {
+    sv = signed_video_create(list->codec);
+    internal_sv = true;
+  }
+
+  signed_video_authenticity_t *auth_report = NULL;
+  signed_video_latest_validation_t *latest = NULL;
+
+  int valid_gops = 0;
+  int valid_gops_with_missing_info = 0;
+  int invalid_gops = 0;
+  int unsigned_gops = 0;
+  int missed_nalus = 0;
+  int pending_nalus = 0;
+  int has_signature = 0;
+  bool public_key_has_changed = false;
+  bool has_timestamp = false;
+  // Pop one NAL Unit at a time.
+  test_stream_item_t *item = test_stream_pop_first_item(list);
+  while (item) {
+    SignedVideoReturnCode rc =
+        signed_video_add_nalu_and_authenticate(sv, item->data, item->data_size, &auth_report);
+    ck_assert_int_eq(rc, SV_OK);
+
+    if (auth_report) {
+      latest = &(auth_report->latest_validation);
+      ck_assert(latest);
+      if (latest->number_of_expected_picture_nalus >= 0) {
+        missed_nalus +=
+            latest->number_of_expected_picture_nalus - latest->number_of_received_picture_nalus;
+      }
+      pending_nalus += latest->number_of_pending_picture_nalus;
+      switch (latest->authenticity) {
+        case SV_AUTH_RESULT_OK_WITH_MISSING_INFO:
+          valid_gops_with_missing_info++;
+          break;
+        case SV_AUTH_RESULT_OK:
+          valid_gops++;
+          break;
+        case SV_AUTH_RESULT_NOT_OK:
+          invalid_gops++;
+          break;
+        case SV_AUTH_RESULT_SIGNATURE_PRESENT:
+          has_signature++;
+          break;
+        case SV_AUTH_RESULT_NOT_SIGNED:
+          unsigned_gops++;
+          break;
+        default:
+          break;
+      }
+      public_key_has_changed |= latest->public_key_has_changed;
+      has_timestamp |= latest->has_timestamp;
+
+      if (latest->has_timestamp) {
+        ck_assert_int_eq(latest->timestamp, g_testTimestamp);
+      }
+
+      // Check if product_info has been received and set correctly.
+      if ((latest->authenticity != SV_AUTH_RESULT_NOT_SIGNED) &&
+          (latest->authenticity != SV_AUTH_RESULT_SIGNATURE_PRESENT)) {
+        ck_assert_int_eq(strcmp(auth_report->product_info.hardware_id, HW_ID), 0);
+        ck_assert_int_eq(strcmp(auth_report->product_info.firmware_version, FW_VER), 0);
+        ck_assert_int_eq(strcmp(auth_report->product_info.serial_number, SER_NO), 0);
+        ck_assert_int_eq(strcmp(auth_report->product_info.manufacturer, MANUFACT), 0);
+        ck_assert_int_eq(strcmp(auth_report->product_info.address, ADDR), 0);
+        // Check if code version used when signing the video is equal to the code version used when
+        // validating the authenticity.
+        ck_assert(!signed_video_compare_versions(
+            auth_report->version_on_signing_side, auth_report->this_version));
+      }
+      // Get an authenticity report from separate API and compare accumulated results.
+      signed_video_authenticity_t *extra_auth_report = signed_video_get_authenticity_report(sv);
+      ck_assert_int_eq(
+          memcmp(&auth_report->accumulated_validation, &extra_auth_report->accumulated_validation,
+              sizeof(signed_video_accumulated_validation_t)),
+          0);
+      signed_video_authenticity_report_free(extra_auth_report);
+
+      // We are done with auth_report.
+      latest = NULL;
+      signed_video_authenticity_report_free(auth_report);
+    }
+    // Free item and pop a new one.
+    test_stream_item_free(item);
+    item = test_stream_pop_first_item(list);
+  }
+  // Check GOP statistics against expected.
+  ck_assert_int_eq(valid_gops, expected.valid_gops);
+  ck_assert_int_eq(valid_gops_with_missing_info, expected.valid_gops_with_missing_info);
+  ck_assert_int_eq(invalid_gops, expected.invalid_gops);
+  ck_assert_int_eq(unsigned_gops, expected.unsigned_gops);
+  ck_assert_int_eq(missed_nalus, expected.missed_nalus);
+  ck_assert_int_eq(pending_nalus, expected.pending_nalus);
+  ck_assert_int_eq(has_signature, expected.has_signature);
+  ck_assert_int_eq(public_key_has_changed, expected.public_key_has_changed);
+  ck_assert_int_eq(has_timestamp, !expected.has_no_timestamp);
+
+  // Get the authenticity report and compare the stats against expected.
+  if (expected.final_validation) {
+    auth_report = signed_video_get_authenticity_report(sv);
+    ck_assert_int_eq(
+        auth_report->accumulated_validation.authenticity, expected.final_validation->authenticity);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_has_changed,
+        expected.final_validation->public_key_has_changed);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_received_nalus,
+        expected.final_validation->number_of_received_nalus);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_validated_nalus,
+        expected.final_validation->number_of_validated_nalus);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_pending_nalus,
+        expected.final_validation->number_of_pending_nalus);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_validation,
+        expected.final_validation->public_key_validation);
+    ck_assert_int_eq(auth_report->accumulated_validation.has_timestamp,
+        expected.final_validation->has_timestamp);
+    signed_video_authenticity_report_free(auth_report);
+  }
+
+  if (internal_sv) signed_video_free(sv);
+}
+#endif
+
 /* Test description
  * The public APIs are checked for invalid parameters.
  */
@@ -76,6 +236,2034 @@ START_TEST(invalid_api_inputs)
 }
 END_TEST
 
+#if 0
+/* Test description
+ * Verify that we get a valid authentication if all NAL Units are added in the correct order.
+ * The operation is as follows:
+ * 1. Generate a test stream with a sequence of signed GOPs.
+ * 2. Add these in the same order as they were generated.
+ * 3. Check the authentication result
+ */
+START_TEST(intact_stream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Create a list of NAL Units given the input string.
+  test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSIPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 26, 25, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 7, .pending_nalus = 7, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(intact_multislice_stream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IiPpPpIiPpPpIi", settings[_i]);
+  test_stream_check_types(list, "SIiPpPpSIiPpPpSIi");
+
+  // All NAL Units but the last 'I' and 'i' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 17, 15, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(intact_stream_with_splitted_nalus)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Create a list of NAL Units given the input string.
+  test_stream_t *list = create_signed_splitted_nalus("IPPIPPIPPIPPIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSIPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 26, 25, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // For expected values see the "intact_stream" test above.
+  struct validation_stats expected = {
+      .valid_gops = 7, .pending_nalus = 7, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* The action here is only correct in the NAL unit stream format. If we use the bytestream format,
+ * the PPS is prepended the 'I' in the same AU, hence, the prepending function will add the
+ * SEI(s) before the PPS. */
+START_TEST(intact_stream_with_pps_nalu_stream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("VIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "VSIPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(intact_stream_with_pps_bytestream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("VIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "VSIPPSIPPSI");
+
+  // Pop the PPS NAL Unit and inject it before the 'I'.
+  test_stream_item_t *item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'V');
+  test_stream_check_types(list, "SIPPSIPPSI");
+  test_stream_append_item(list, item, 1);
+  test_stream_check_types(list, "SVIPPSIPPSI");
+
+  // SVIPPSIPPSI
+  //
+  // SVI         -> (valid) ._P   (1 pending)
+  //   IPPSI     -> (valid) ....P (1 pending)
+  //       IPPSI -> (valid) ....P (1 pending)
+  // One pending NAL Unit per GOP.
+  // All NAL Units but the last 'I' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(intact_ms_stream_with_pps_nalu_stream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i]);
+  test_stream_check_types(list, "VSIiPpPpSIiPpPpSIi");
+
+  // All NAL Units but the last 'I' and 'i' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(intact_ms_stream_with_pps_bytestream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("VIiPpPpIiPpPpIi", settings[_i]);
+  test_stream_check_types(list, "VSIiPpPpSIiPpPpSIi");
+
+  // Pop the PPS NAL Unit and inject it before the 'I'.
+  test_stream_item_t *item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'V');
+  test_stream_check_types(list, "SIiPpPpSIiPpPpSIi");
+  test_stream_append_item(list, item, 1);
+  test_stream_check_types(list, "SVIiPpPpSIiPpPpSIi");
+
+  // All NAL Units but the last 'I' and 'i' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we get a valid authentication if all NAL Units are added in the correct order and one
+ * NAL Unit is undefined.
+ * The operation is as follows:
+ * 1. Generate a test stream with a sequence of signed GOPs.
+ * 2. Add these in the same order as they were generated.
+ * 3. Check the authentication result
+ */
+START_TEST(intact_with_undefined_nalu_in_stream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPXPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPXPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 11, 10, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(intact_with_undefined_multislice_nalu_in_stream)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IiPpXPpIiPpPpIi", settings[_i]);
+  test_stream_check_types(list, "SIiPpXPpSIiPpPpSIi");
+
+  // All NAL Units but the last 'I' and 'i' are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 18, 16, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 3, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we get invalid authentication if we remove one 'P'. The operation is as follows:
+ * 1. Generate a test stream with a sequence of signed GOPs.
+ * 2. Remove one 'P' in the middle GOP.
+ * 3. Check the authentication result
+ */
+START_TEST(remove_one_p_nalu)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPPSIPPSI");
+
+  // Item counting starts at 1.  Middle 'P' in second non-empty GOP: SIPPSIP P PSIPPSI
+  const int remove_nalu_number = 8;
+  remove_item_then_check_and_free(list, remove_nalu_number, 'P');
+  test_stream_check_types(list, "SIPPSIPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated and since one NAL Unit has been removed the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 14, 13, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
+      .missed_nalus = 1,
+      .pending_nalus = 4,
+      .final_validation = &final_validation};
+  // For Frame level we can identify the missing NAL Unit and mark the GOP as valid with missing
+  // info.
+  if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    expected.valid_gops = 3;
+    expected.valid_gops_with_missing_info = 1;
+    expected.invalid_gops = 0;
+    expected.final_validation->authenticity = SV_AUTH_RESULT_OK_WITH_MISSING_INFO;
+  }
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we get invalid authentication if we interchange two 'P's.
+ */
+START_TEST(interchange_two_p_nalus)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPPSIPPSI");
+
+  // Item counting starts at 1.  Middle 'P' in second non-empty GOP: SIPPSIP P PSIPPSI
+  const int nalu_number = 8;
+  test_stream_item_t *item = test_stream_item_remove(list, nalu_number);
+  test_stream_item_check_type(item, 'P');
+
+  // Inject the item again, but at position nalu_number + 1, that is, append the list item at
+  // position nalu_number.
+  test_stream_append_item(list, item, nalu_number);
+  test_stream_check_types(list, "SIPPSIPPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated and since two NAL Units have been moved the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
+      .pending_nalus = 4,
+      .final_validation = &final_validation};
+  // For Frame level we can identify the I NAL Unit, hence the linking between GOPs is intact.
+  if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    expected.valid_gops = 3;
+    expected.invalid_gops = 1;
+    expected.final_validation->number_of_validated_nalus = 14;
+  }
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that if we manipulate a NAL Unit, the authentication should become invalid. We do this for
+ * both a P- and an 'I', by replacing the NAL Unit data with a modified NAL Unit.
+ */
+START_TEST(modify_one_p_nalu)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPPSIPPSI");
+
+  // Second 'P' in first non-empty GOP: SIP P SIPPPSIPPSI
+  const int modify_nalu_number = 4;
+  modify_list_item(list, modify_nalu_number, 'P');
+
+  // All NAL Units but the last 'I' are validated and since one NAL Unit has been modified the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
+      .pending_nalus = 4,
+      .final_validation = &final_validation};
+  // For Frame level we can identify the I NAL Unit, hence the linking between GOPs is intact.
+  if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    expected.valid_gops = 3;
+    expected.invalid_gops = 1;
+  }
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(modify_one_i_nalu)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPPSIPPSI");
+
+  // Modify the 'I' in second non-empty GOP: SIPPS I PPPSIPPSI
+  const int modify_nalu_number = 6;
+  modify_list_item(list, modify_nalu_number, 'I');
+
+  // All NAL Units but the last 'I' are validated and since one 'I' has been modified the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP. Note that a modified 'I' affects two GOPs due to linked hashes,
+  // but it will also affect a third if we validate with a gop_hash.
+  struct validation_stats expected = {.valid_gops = 1,
+      .invalid_gops = 3,
+      .pending_nalus = 4,
+      .final_validation = &final_validation};
+  // For Frame level, the first GOP will be marked as valid with missing info since we cannot
+  // correctly validate the last NAL Unit (the modified I).
+  if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    expected.valid_gops = 2;
+    expected.invalid_gops = 2;
+  }
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we get invalid authentication if we remove a SEI or an 'I'. The operation is
+ * as follows:
+ * 1. Generate a test stream with a sequence of four signed GOPs.
+ * 2. Remove a SEI or an 'I' after the second GOP.
+ * 3. Check the authentication result */
+START_TEST(remove_the_g_nalu)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSI");
+
+  // SEI of second non-empty GOP: SIPPSIPP S IPPSIPPSI.
+  const int remove_nalu_number = 9;
+  remove_item_then_check_and_free(list, remove_nalu_number, 'S');
+  test_stream_check_types(list, "SIPPSIPPIPPSIPPSI");
+
+  // SIPPSIPPIPPSIPPSI
+  //
+  // SI                ->   (valid) -> .P
+  //  IPPSI            ->   (valid) -> ....P
+  //      IPPIPPS      -> (invalid) -> NNNPPPP
+  //         IPPSI     -> (invalid) -> N...P
+  //             IPPSI ->   (valid) -> ....P
+  // All NAL Units but the last 'I' are validated and since one SEI has been removed the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 3,
+      .invalid_gops = 2,
+      .pending_nalus = 8,
+      .final_validation = &final_validation};
+
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(remove_the_i_nalu)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSI");
+
+  // 'I' of third non-empty GOP: SIPPSIPPS I PPSIPPSI.
+  const int remove_nalu_number = 10;
+  remove_item_then_check_and_free(list, remove_nalu_number, 'I');
+  test_stream_check_types(list, "SIPPSIPPSPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated and since one 'I' has been removed the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP. A missing I NAL Unit will affect two GOPs, since it is part of
+  // two gop_hashes. At GOP level the missing NAL Unit will make the GOP invalid, but for Frame
+  // level we can identify the missed NAL Unit when the I NAL Unit is not the reference, that is,
+  // the first GOP is valid with missing info, whereas the second becomes invalid. SIPPSIPPSPPSIPPSI
+  //
+  // SI                ->   (valid) -> .P
+  //  IPPSI            ->   (valid) -> ....P
+  //      IPPSP        -> (invalid) -> NNNNP
+  //          PPSI     -> (invalid) -> MNNNP (1 missing)
+  //             IPPSI -> (invalid) -> N...P
+  struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 3,
+      .missed_nalus = 1,
+      .pending_nalus = 5,
+      .final_validation = &final_validation};
+  if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    // SI                ->   (valid) -> .P
+    //  IPPSI            ->   (valid) -> ....P
+    //      IPPSP        ->   (valid) -> ....P
+    //          PPSI     -> (invalid) -> MNNNP (1 missing)
+    //             IPPSI -> (invalid) -> N...P
+    expected.valid_gops = 3;
+    expected.invalid_gops = 2;
+  }
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(remove_the_gi_nalus)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSI");
+
+  // SEI of second non-empty GOP: SIPPSIPP S IPPSIPPSI.
+  int remove_nalu_number = 9;
+  remove_item_then_check_and_free(list, remove_nalu_number, 'S');
+  // Note that we have removed an item before this one, hence the 'I' is now at place 9:
+  // SIPPSIPP I PPSIPPS.
+  remove_item_then_check_and_free(list, remove_nalu_number, 'I');
+  test_stream_check_types(list, "SIPPSIPPPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated and since one couple of SEI and 'I' have been
+  // removed the authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 16, 15, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per detected GOP. Note that we lose one 'true' GOP since the transition is
+  // lost. We have now two incomplete GOPs; second (missing S) and third (missing I). In fact, we
+  // miss the transition between GOP two and three, but will detect it later through the gop
+  // counter. Unfortunately, the authentication result does not cover the case "invalid gop" and
+  // "missing gops", so we cannot get that information. This will be solved when changing to a more
+  // complete authentication report.
+  struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
+      .missed_nalus = -2,
+      .pending_nalus = 4,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we can validate authenticity if the SEI arrives late. This is simulated by
+ * moving the SEI to a 'P' in the next GOP.
+ */
+START_TEST(sei_arrives_late)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPPIPPPIPPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPPSIPPPSIPPPSI");
+
+  // Remove the second SEI, that is, number 6 in the list: SIPPP (S) IPPPSIPPPSI.
+  test_stream_item_t *sei = test_stream_item_remove(list, 6);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_check_types(list, "SIPPPIPPPSIPPPSI");
+
+  // Prepend the middle P of the next GOP: SIPPPIP (S)P PSIPPPSI. This is equivalent with appending
+  // the first P of the same GOP, that is, number 7.
+  test_stream_append_item(list, sei, 7);
+  test_stream_check_types(list, "SIPPPIPSPPSIPPPSI");
+
+  // All NAL Units but the last 'I' are validated as OK, which is pending.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP + the extra P before (S). The late arrival SEI will introduce one
+  // pending NAL Unit (the P frame right before).
+  struct validation_stats expected = {
+      .valid_gops = 4, .pending_nalus = 5, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+// TODO: Generalize this function.
+/* Helper function that generates a fixed list with delayed SEIs. */
+static test_stream_t *
+generate_delayed_sei_list(struct sv_setting setting, bool extra_delay)
+{
+  // Make first GOP one P-frame longer to trigger recurrence on second I-frame.
+  test_stream_t *list = create_signed_nalus("IPPPPIPPPIPPPIPPPIP", setting);
+  test_stream_check_types(list, "SIPPPPSIPPPSIPPPSIPPPSIP");
+
+  // Remove each SEI in the list and append it 2 items later (which in practice becomes 1 item later
+  // since we just removed the SEI).
+  int extra_offset = extra_delay ? 5 : 0;
+  int extra_correction = extra_delay ? 1 : 0;
+  test_stream_item_t *sei = test_stream_item_remove(list, 1);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 2 + extra_offset);
+  sei = test_stream_item_remove(list, 7 - extra_correction);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 8 + extra_offset);
+  sei = test_stream_item_remove(list, 12 - extra_correction);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 13 + extra_offset);
+  sei = test_stream_item_remove(list, 17 - extra_correction);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 18 + extra_offset);
+  sei = test_stream_item_remove(list, 22 - extra_correction);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 23);
+
+  if (extra_delay) {
+    test_stream_check_types(list, "IPPPPISPPPIPSPPIPSPPIPSS");
+  } else {
+    test_stream_check_types(list, "IPSPPPIPSPPIPSPPIPSPPIPS");
+  };
+  return list;
+}
+
+/* Test description
+ * Verify that we can validate authenticity if all SEIs arrive late. This is simulated by moving
+ * each SEI to a P in the next GOP.
+ */
+START_TEST(all_seis_arrive_late)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = generate_delayed_sei_list(settings[_i], true);
+
+  // IPPPPISPPPIPSPPIPSPPIPSS
+  //
+  // IPPPPI                   -> (no signature) -> PPPPPP         6 pending
+  // IPPPPIS                  ->        (valid) -> PPPPPP.        6 pending
+  // IPPPPISPPPIPS            ->        (valid) -> .....P.PPPPP.  6 pending
+  //      ISPPPIPSPPIPS       ->        (valid) -> .....PP.PPPP.  6 pending
+  //           IPSPPIPSPPIPS  ->        (valid) -> .....PP.PPPP.  6 pending
+  //                IPSPPIPSS ->        (valid) -> .....PP..      2 pending
+  //                                                32 pending
+  // All NAL Units but the last 'I', 'P' and 2 SEIs are validated as OK, hence four pending NAL
+  // Units.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 24, 20, 4, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 5,
+      .unsigned_gops = 1,
+      .pending_nalus = 32,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(all_seis_arrive_late_first_gop_scrapped)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = generate_delayed_sei_list(settings[_i], true);
+
+  test_stream_item_t *item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'I');
+  test_stream_check_types(list, "PPPPISPPPIPSPPIPSPPIPSS");
+  test_stream_item_free(item);
+  item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'P');
+  test_stream_check_types(list, "PPPISPPPIPSPPIPSPPIPSS");
+  test_stream_item_free(item);
+  item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'P');
+  test_stream_check_types(list, "PPISPPPIPSPPIPSPPIPSS");
+  test_stream_item_free(item);
+  item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'P');
+  test_stream_check_types(list, "PISPPPIPSPPIPSPPIPSS");
+  test_stream_item_free(item);
+  item = test_stream_pop_first_item(list);
+  test_stream_item_check_type(item, 'P');
+  test_stream_check_types(list, "ISPPPIPSPPIPSPPIPSS");
+  test_stream_item_free(item);
+
+  // ISPPPIPSPPIPSPPIPSS
+  //
+  // IS                  ->    (signature) -> PU             1 pending
+  // ISPPPIPS            ->    (signature) -> PUPPPPPU       6 pending
+  // ISPPPIPSPPIPS       ->        (valid) -> .U...PPUPPPP.  6 pending
+  //      IPSPPIPSPPIPS  ->        (valid) -> ..U..PP.PPPP.  6 pending
+  //           IPSPPIPSS ->        (valid) -> .....PP..      2 pending
+  //                                                        21 pending
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 19, 15, 4, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 3,
+      .has_signature = 2,
+      .pending_nalus = 21,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we can validate authenticity correctly if the SEI arrives late with a lost SEI
+ * the GOP before.
+ */
+START_TEST(lost_g_before_late_sei_arrival)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPPSIPPPSIPPPSIPPSI");
+
+  // Remove the third SEI, that is, number 11 in the list: SIPPPSIPPP (S) IPPPSIPPSI.
+  test_stream_item_t *sei = test_stream_item_remove(list, 11);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_check_types(list, "SIPPPSIPPPIPPPSIPPSI");
+
+  // Prepend the middle P of the next GOP: SIPPPSIPPPIP (S)P PSIPPSI. This is equivalent with
+  // appending the first P of the same GOP, that is, number 12.
+
+  test_stream_append_item(list, sei, 12);
+  test_stream_check_types(list, "SIPPPSIPPPIPSPPSIPPSI");
+
+  // Remove the second SEI, i.e., number 6 in the list: SIPPP (S) IPPPIPSPPSIPPSI.
+  remove_item_then_check_and_free(list, 6, 'S');
+  test_stream_check_types(list, "SIPPPIPPPIPSPPSIPPSI");
+
+  // SI                   ->   (valid) -> .P           1 pending
+  //  IPPPIPPPIPS         -> (invalid) -> NNNNN...PP.  2 pending (two GOPs in one validation)
+  //          IPSPPSI     ->   (valid) -> ......P      1 pending
+  //                IPPSI ->   (valid) -> ....P        1 pending
+  //                                             5 pending
+  // All NAL Units but the last 'I' are validated. Since a SEI is lost the authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 20, 19, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 3,
+      .invalid_gops = 1,
+      .pending_nalus = 5,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Consider a scenario where the validation side starts recording a video stream from the second
+ * GOP, and the SEIs arrive late. This test validates proper results if the second SEI is lost and
+ * the first SEI arrives inside the second GOP.
+ */
+START_TEST(lost_g_and_gop_with_late_sei_arrival)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  if (TMP_FIX_TO_ALLOW_TWO_INVALID_SEIS_AT_STARTUP) return;
+
+  test_stream_t *list = create_signed_nalus("IPIPPPIPPPIP", settings[_i]);
+  test_stream_check_types(list, "SIPSIPPPSIPPPSIP");
+
+  // Get the first SEI, to be added back later.
+  test_stream_item_t *sei = test_stream_pop_first_item(list);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_check_types(list, "IPSIPPPSIPPPSIP");
+
+  // Remove the first GOP to mimic the start of the validation side.
+  remove_item_then_check_and_free(list, 1, 'I');
+  test_stream_check_types(list, "PSIPPPSIPPPSIP");
+  remove_item_then_check_and_free(list, 1, 'P');
+  test_stream_check_types(list, "SIPPPSIPPPSIP");
+  remove_item_then_check_and_free(list, 1, 'S');
+  test_stream_check_types(list, "IPPPSIPPPSIP");
+
+  // Inject the SEI into the second GOP.
+  test_stream_append_item(list, sei, 2);
+  test_stream_check_types(list, "IPSPPSIPPPSIP");
+
+  // Move the remaining SEIs.
+  sei = test_stream_item_remove(list, 6);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_check_types(list, "IPSPPIPPPSIP");
+  test_stream_append_item(list, sei, 7);
+  test_stream_check_types(list, "IPSPPIPSPPSIP");
+
+  sei = test_stream_item_remove(list, 11);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_check_types(list, "IPSPPIPSPPIP");
+  test_stream_append_item(list, sei, 12);
+  test_stream_check_types(list, "IPSPPIPSPPIPS");
+
+  // IPS            -> (signature) -> PPU
+  // IPSPPIPS*      ->     (valid) -> ..U..PP.
+  //      IPS*PPIPS ->     (valid) -> .....PP.
+  // All NAL Units but the last three NAL Units are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 13, 10, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 2,
+      .pending_nalus = 6,
+      .has_signature = 1,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we can validate authenticity correctly if we lose all NAL Units between two SEIs. */
+START_TEST(lost_all_nalus_between_two_seis)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPPIPPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPPSIPPPSIPPPSIPPSI");
+
+  // Remove IPPP between the second and third S.
+  remove_item_then_check_and_free(list, 7, 'I');
+  remove_item_then_check_and_free(list, 7, 'P');
+  remove_item_then_check_and_free(list, 7, 'P');
+  remove_item_then_check_and_free(list, 7, 'P');
+  test_stream_check_types(list, "SIPPPSSIPPPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated. Since all NAL Units between two SEIs are lost the
+  // authenticity is NOT OK.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 17, 16, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // We have NAL Units from 5 GOPs present and each GOP will produce one pending NAL Unit. The lost
+  // NAL Units (IPPP) will be detected, but for SV_AUTHENTICITY_LEVEL_FRAME we will measure one
+  // extra missing NAL Unit. This is a descrepancy in the way we count NAL Units by excluding SEIs.
+  //
+  // SIPPPSSIPPPSIPPSI
+  //
+  // SI                ->   (valid) -> .P
+  //  IPPPSS           -> (invalid) -> NNNNNP
+  //       SI          -> (invalid) -> MMMMNP (4 missed)
+  //        IPPPSI     -> (invalid) -> N....P
+  //             IPPSI ->   (valid) -> ....P
+  struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 3,
+      .missed_nalus = 4,
+      .pending_nalus = 5,
+      .final_validation = &final_validation};
+  if (settings[_i].auth_level == SV_AUTHENTICITY_LEVEL_FRAME) {
+    // SIPPPSSIPPPSIPPSI
+    //
+    // SI                ->   (valid) -> .P
+    //  IPPPSS           ->   (valid) -> .....P
+    //       SI          -> (invalid) -> MMMM.P (4 missed)
+    //        IPPPSI     -> (invalid) -> N....P
+    //             IPPSI ->   (valid) -> ....P
+    expected.valid_gops = 3;
+    expected.invalid_gops = 2;
+  }
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we get a valid authentication if a SEI has been added between signing and
+ * authentication.
+ */
+START_TEST(add_one_sei_nalu_after_signing)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPPIPPI", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPPSIPPSI");
+
+  const uint8_t id = 0;
+  test_stream_item_t *sei = test_stream_item_create_from_type('Z', id, settings[_i].codec);
+
+  // Middle 'P' in second non-empty GOP: SIPPSIP P(Z) PSIPPSI
+  const int append_nalu_number = 8;
+  test_stream_append_item(list, sei, append_nalu_number);
+  test_stream_check_types(list, "SIPPSIPPZPSIPPSI");
+
+  // All NAL Units but the last 'I' are validated as OK. The last one is pending.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 16, 15, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 4, .pending_nalus = 4, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we do get a valid authentication if the signing on the camera was reset. From a
+ * signed video perspective this action is correct as long as recorded NAL Units are not transmitted
+ * while the signing is down. That would on the other hand be detected at the client side through a
+ * failed validation. The operation is as follows:
+ * 1. Generate a test stream with a sequence of signed GOPs.
+ * 2. Generate a second test stream with a sequence of signed GOPs and concatenate lists.
+ * 3. Run all NAL Units through the validator.
+ */
+START_TEST(camera_reset_on_signing_side)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Generate 2 GOPs
+  test_stream_t *list = create_signed_nalus("IPPIPP", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPP");
+
+  // Generate another GOP from scratch
+  test_stream_t *list_after_reset = create_signed_nalus_int("IPPPI", settings[_i], true);
+  test_stream_check_types(list_after_reset, "SIPPPSI");
+
+  test_stream_append(list, list_after_reset);
+  test_stream_check_types(list, "SIPPSIPPSIPPPSI");
+
+  // Final validation is NOT OK and all received NAL Units, but the last, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, true, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP. Note that the mid GOP (IPPSI) includes the reset on the camera.
+  // It will be marked as invalid and compute 3 more NAL Units than expected. In S it is
+  // communicated there is only 2 NAL Units present (SI). So missed NAL Units equals -3 (IPP).
+  // TODO: public_key_has_changed is expected to be true now when we have changed the behavior in
+  // generate private key.
+  const struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
+      .missed_nalus = -3,
+      .pending_nalus = 4,
+      .public_key_has_changed = true,
+      .final_validation = &final_validation};
+
+  validate_test_stream(NULL, list, expected);
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ */
+START_TEST(detect_change_of_public_key)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Generate 2 GOPs
+  test_stream_t *list = create_signed_nalus("IPPIPP", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPP");
+
+  // Generate another GOP from scratch
+  // This will generate a new private key, hence transmit a different public key.
+  test_stream_t *list_with_new_public_key = create_signed_nalus_int("IPPPI", settings[_i], true);
+  test_stream_check_types(list_with_new_public_key, "SIPPPSI");
+
+  test_stream_append(list, list_with_new_public_key);
+  test_stream_check_types(list, "SIPPSIPPSIPPPSI");
+
+  // Final validation is NOT OK and all received NAL Units, but the last, are validated. The
+  // |public_key_has_changed| flag has been set.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, true, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // The list will be validated successfully up to the third SEI (S) which has the new Public key.
+  //
+  //   SI      -> .P     (valid, 1 pending, public_key_has_changed = false)
+  //   IPPSI   -> ....P  (valid, 1 pending, public_key_has_changed = false)
+  //   IPPS*I  -> NNN.P  (invalid, 1 pending, public_key_has_changed = true, -3 missing)
+  //   IPPPS*I -> N....P (invalid, 1 pending, public_key_has_changed = false)
+  // where S* has the new Public key. Note that we get -3 missing since we receive 3 more than what
+  // is expected according to S*.
+  const struct validation_stats expected = {.valid_gops = 2,
+      .invalid_gops = 2,
+      .missed_nalus = -3,
+      .pending_nalus = 4,
+      .public_key_has_changed = true,
+      .final_validation = &final_validation};
+
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Fast forward a recording will move to a new location, but only at 'I'. If we use the access
+ * unit (AU) format 'I's may be prepended with SEIs. When fast forwarding the user has to
+ * call the signed_video_reset function otherwise the first verification will become invalid. We
+ * test both cases.
+ *
+ * The operation is as follows:
+ * 1. Generate a test stream with a sequence of signed GOPs.
+ * 2. Pop a new list from it with one complete GOP of nalus. Validate the new list.
+ * 3. Remove all NAL Units until the next SEI. With the access unit format, the SEI is
+ *    sent together with the 'I'.
+ * 4a. Reset the session, and validate.
+ * 4b. Validate without a reset.
+ */
+static test_stream_t *
+mimic_au_fast_forward_and_get_list(signed_video_t *sv, struct sv_setting setting)
+{
+  test_stream_t *list = create_signed_nalus("IPPPPIPPPIPPPIPPPIPPPI", setting);
+  test_stream_check_types(list, "SIPPPPSIPPPSIPPPSIPPPSIPPPSI");
+
+  // Extract the first 9 NAL Units from the list. This should be the empty GOP, a full GOP and in
+  // the middle of the next GOP: SIPPPPSIP PPSIPPPSIPPPSI. These are the NAL Units to be processed
+  // before the fast forward.
+  test_stream_t *pre_fast_forward = test_stream_pop(list, 9);
+  test_stream_check_types(pre_fast_forward, "SIPPPPSIP");
+  test_stream_check_types(list, "PPSIPPPSIPPPSIPPPSI");
+
+  // Final validation of |pre_fast_forward| is OK and all received NAL Units, but the last two, are
+  // validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 9, 7, 2, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // Validate the video before fast forward using the user created session |sv|.
+  //
+  // SI      -> .P          (valid)
+  // IPPPPSI ->  .....P     (valid)
+  //
+  // Total number of pending NAL Units = 1 + 1 = 2
+  struct validation_stats expected = {
+      .valid_gops = 2, .pending_nalus = 2, .final_validation = &final_validation};
+  validate_test_stream(sv, pre_fast_forward, expected);
+  test_stream_free(pre_fast_forward);
+
+  // Mimic fast forward by removing 7 NAL Units ending up at the second next SEI: PSIPP SIPPSIPPSI.
+  // A fast forward is always done to an 'I', and if we use the access unit (AU) format, also the
+  // preceding SEI will be present.
+  int remove_items = 7;
+  while (remove_items--) {
+    test_stream_item_t *item = test_stream_pop_first_item(list);
+    test_stream_item_free(item);
+  }
+  test_stream_check_types(list, "SIPPPSIPPPSI");
+
+  return list;
+}
+
+START_TEST(fast_forward_stream_with_reset)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Create a session.
+  signed_video_t *sv = signed_video_create(settings[_i].codec);
+  ck_assert(sv);
+  ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
+  test_stream_t *list = mimic_au_fast_forward_and_get_list(sv, settings[_i]);
+  // Reset session before we start validating.
+  ck_assert_int_eq(signed_video_reset(sv), SV_OK);
+
+  // Final validation is OK and all received NAL Units, but the last one, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 12, 11, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // Validate SIPPPSIPPPSI:
+  //
+  // SI      -> UP           (SV_AUTH_RESULT_SIGNATURE_PRESENT)
+  // SIPPPSI -> U.....P      (valid)
+  // IPPPSI  ->       .....P (valid)
+  //
+  // Total number of pending NAL Units = 1 + 1 + 1 = 3
+  const struct validation_stats expected = {.valid_gops = 2,
+      .pending_nalus = 3,
+      .has_signature = 1,
+      .final_validation = &final_validation};
+
+  validate_test_stream(sv, list, expected);
+  // Free list and session.
+  signed_video_free(sv);
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(fast_forward_stream_without_reset)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Create a session.
+  signed_video_t *sv = signed_video_create(settings[_i].codec);
+  ck_assert(sv);
+  ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
+  test_stream_t *list = mimic_au_fast_forward_and_get_list(sv, settings[_i]);
+
+  // Final validation is NOT OK and all received NAL Units, but the last one, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 21, 20, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // Validate IP SIPPPSIPPPSI (without reset, i.e., started with IP before fast forward):
+  //
+  // SI      -> NMMUP           (invalid, 2 missing)
+  // SIPPPSI ->    UN....P      (invalid)
+  // IPPPSI  ->          .....P (valid)
+  //
+  // Total number of pending NAL Units = 1 + 1 + 1 = 3
+  const struct validation_stats expected = {.valid_gops = 1,
+      .invalid_gops = 2,
+      .missed_nalus = 2,
+      .pending_nalus = 3,
+      .final_validation = &final_validation};
+
+  validate_test_stream(sv, list, expected);
+
+  // Free list and session.
+  test_stream_free(list);
+  signed_video_free(sv);
+}
+END_TEST
+
+static test_stream_t *
+mimic_au_fast_forward_on_late_seis_and_get_list(signed_video_t *sv, struct sv_setting setting)
+{
+  test_stream_t *list = generate_delayed_sei_list(setting, false);
+  test_stream_check_types(list, "IPSPPPIPSPPIPSPPIPSPPIPS");
+
+  // Extract the first 9 NAL Units from the list. This should be the empty GOP, a full GOP and in
+  // the middle of the next GOP: IPSPPPIPS PPIPSPPIPSPPIPS. These are the NAL Units to be processed
+  // before the fast forward.
+  test_stream_t *pre_fast_forward = test_stream_pop(list, 9);
+  test_stream_check_types(pre_fast_forward, "IPSPPPIPS");
+  test_stream_check_types(list, "PPIPSPPIPSPPIPS");
+
+  // Final validation of |pre_fast_forward| is OK and all received NAL Units, but the last three,
+  // are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 9, 6, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // Validate the video before fast forward using the user created session |sv|.
+  //
+  // IPS         -> PP.         (valid)
+  // IPSPPPIPS   -> ......PP.   (valid)
+  //
+  // Total number of pending NAL Units = 2 + 2 = 4
+  struct validation_stats expected = {
+      .valid_gops = 2, .pending_nalus = 4, .final_validation = &final_validation};
+  validate_test_stream(sv, pre_fast_forward, expected);
+  test_stream_free(pre_fast_forward);
+
+  // Mimic fast forward by removing 7 NAL Units ending up at the start of a later GOP: PPIPSPP
+  // IPSPPIPS. A fast forward is always done to an 'I'. The first SEI showing up is associated with
+  // the now removed NAL Units.
+  int remove_items = 7;
+  while (remove_items--) {
+    test_stream_item_t *item = test_stream_pop_first_item(list);
+    test_stream_item_free(item);
+  }
+  test_stream_check_types(list, "IPSPPIPS");
+
+  return list;
+}
+
+START_TEST(fast_forward_stream_with_delayed_seis)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  // Create a new session.
+  signed_video_t *sv = signed_video_create(settings[_i].codec);
+  ck_assert(sv);
+  ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
+  test_stream_t *list = mimic_au_fast_forward_on_late_seis_and_get_list(sv, settings[_i]);
+  // Reset session before we start validating.
+  ck_assert_int_eq(signed_video_reset(sv), SV_OK);
+
+  // Final validation is OK and all received NAL Units, but the last three, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 8, 5, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // Validate IPSPPIPS:
+  //
+  // IPS      -> PPU           (SV_AUTH_RESULT_SIGNATURE_PRESENT)
+  // IPSPPIPS -> ..U..PP.      (valid)
+  //
+  // Total number of pending NAL Units = 2 + 2 = 4
+  struct validation_stats expected = {.valid_gops = 1,
+      .pending_nalus = 4,
+      .has_signature = 1,
+      .final_validation = &final_validation};
+
+  validate_test_stream(sv, list, expected);
+  // Free list and session.
+  signed_video_free(sv);
+  test_stream_free(list);
+}
+END_TEST
+
+/* Export-to-file tests descriptions
+ * The main scenario for usage is to validate authenticity on exported files. The stream then looks
+ * a little different since we have no start reference.
+ *
+ * Below is a helper function that creates a stream of NAL Units and exports the middle part by
+ * pop-ing GOPs at the beginning and at the end.
+ *
+ * As an additional piece, the stream starts with a PPS/SPS/VPS NAL Unit, which is moved to the
+ * beginning of the "file" as well. That should not affect the validation. */
+static test_stream_t *
+mimic_file_export(struct sv_setting setting, bool include_i_nalu_at_end, bool delayed_seis)
+{
+  test_stream_t *pre_export = NULL;
+  test_stream_t *list = create_signed_nalus("VIPPIPPIPPIPPIPPIPP", setting);
+  test_stream_check_types(list, "VSIPPSIPPSIPPSIPPSIPPSIPP");
+
+  // Remove the initial PPS/SPS/VPS NAL Unit to add back later
+  test_stream_item_t *ps = test_stream_pop_first_item(list);
+  test_stream_item_check_type(ps, 'V');
+
+  if (delayed_seis) {
+    int out[4] = {1, 4, 7, 10};
+    for (int i = 0; i < 4; i++) {
+      test_stream_item_t *sei = test_stream_item_remove(list, out[i]);
+      test_stream_item_check_type(sei, 'S');
+      test_stream_append_item(list, sei, 13);
+    }
+    test_stream_check_types(list, "IPPIPPIPPISSSSPPSIPPSIPP");
+    pre_export = test_stream_pop(list, 6);
+    test_stream_check_types(pre_export, "IPPIPP");
+    test_stream_check_types(list, "IPPISSSSPPSIPPSIPP");
+  } else {
+    // Remove the first 4 NAL Units from the list. This should be the first complete GOP: SIPP
+    // SIPPSIPPSIPPSIPP. These are the NAL Units to be processed before the fast forward.
+    pre_export = test_stream_pop(list, 4);
+    test_stream_check_types(pre_export, "SIPP");
+    test_stream_check_types(list, "SIPPSIPPSIPPSIPPSIPP");
+  }
+
+  // Mimic end of file export by removing items at the end of the list. Here we can take two
+  // approaches, that is, include the 'I' at the end and not. The latter being the standard
+  // operation, which creates a dangling end. The list of NAL Units will after this have 3 GOPs:
+  // SIPPSIPPSIPP(SI).
+  int remove_items = include_i_nalu_at_end ? 2 : 4;
+  while (remove_items--) {
+    test_stream_item_t *item = test_stream_pop_last_item(list);
+    test_stream_item_free(item);
+  }
+  // Prepend list with PPS/SPS/VPS NAL Unit
+  test_stream_prepend_first_item(list, ps);
+
+  if (delayed_seis) {
+    test_stream_check_types(list, include_i_nalu_at_end ? "VIPPISSSSPPSIPPSI" : "VIPPISSSSPPSIPP");
+  } else {
+    test_stream_check_types(
+        list, include_i_nalu_at_end ? "VSIPPSIPPSIPPSIPPSI" : "VSIPPSIPPSIPPSIPP");
+  }
+  test_stream_free(pre_export);
+
+  return list;
+}
+
+START_TEST(file_export_with_dangling_end)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = mimic_file_export(settings[_i], false, false);
+
+  // Create a new session and validate the authenticity of the file.
+  signed_video_t *sv = signed_video_create(settings[_i].codec);
+  ck_assert(sv);
+  // VSIPPSIPPSIPPSIPP (17 NAL Units)
+  //
+  // VSI             -> (signature) -> _UP
+  //   IPPSI         ->     (valid) -> ....P
+  //       IPPSI     ->     (valid) -> ....P
+  //           IPPSI ->     (valid) -> ....P
+  //
+  // One pending NAL Unit per GOP.
+  // Final validation is OK and all received NAL Units, but the last three, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 17, 14, 3, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 3,
+      .pending_nalus = 4,
+      .has_signature = 1,
+      .final_validation = &final_validation};
+
+  validate_test_stream(sv, list, expected);
+
+  // Free list and session.
+  signed_video_free(sv);
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(file_export_without_dangling_end)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = mimic_file_export(settings[_i], true, false);
+
+  // Create a new session and validate the authenticity of the file.
+  signed_video_t *sv = signed_video_create(settings[_i].codec);
+  ck_assert(sv);
+  // VSIPPSIPPSIPPSIPPSI (19 NAL Units)
+  //
+  // VSI                 -> (signature) -> _UP
+  //   IPPSI             ->     (valid) -> ....P
+  //       IPPSI         ->     (valid) -> ....P
+  //           IPPSI     ->     (valid) -> ....P
+  //               IPPSI ->     (valid) -> ....P
+  //
+  // One pending NAL Unit per GOP.
+  // Final validation is OK and all received NAL Units, but the last one, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 19, 18, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  struct validation_stats expected = {.valid_gops = 4,
+      .pending_nalus = 5,
+      .has_signature = 1,
+      .final_validation = &final_validation};
+  validate_test_stream(sv, list, expected);
+  // Free list and session.
+  signed_video_free(sv);
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Verify that we do not get any authentication if the stream has no signature
+ */
+START_TEST(no_signature)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = test_stream_create("IPPIPPIPPIPPI", settings[_i].codec);
+  test_stream_check_types(list, "IPPIPPIPPIPPI");
+
+  // Video is not signed, hence all NAL Units are pending.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_SIGNED, false, 13, 0, 13, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, false, 0, 0};
+  // Note that we are one frame off. The start of a GOP (the I) is reported as end of the previous
+  // GOP. This is not a big deal, since the message is still clear; We have no signed video. We will
+  // always have one GOP pending validation, since we wait for a potential SEI, and will validate
+  // upon the 'next' GOP transition.
+  //
+  // IPPI          -> (PPPP)  (pending, pending, pending, pending)
+  // IPPIPPI       -> (PPPPPPP)
+  // IPPIPPIPPI    -> (PPPPPPPPPP)
+  // IPPIPPIPPIPPI -> (PPPPPPPPPPPPP)
+  //
+  // pending_nalus = 4 + 7 + 10 + 13 = 34
+  const struct validation_stats expected = {.unsigned_gops = 4,
+      .pending_nalus = 34,
+      .has_no_timestamp = true,
+      .final_validation = &final_validation};
+
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+START_TEST(multislice_no_signature)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = test_stream_create("IiPpPpIiPpPpIiPpPpIiPpPpIi", settings[_i].codec);
+  test_stream_check_types(list, "IiPpPpIiPpPpIiPpPpIiPpPpIi");
+
+  // Video is not signed, hence all NAL Units are pending.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_SIGNED, false, 26, 0, 26, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, false, 0, 0};
+  // We will always have one GOP pending validation, since we wait for a potential SEI, and will
+  // validate upon the 'next' GOP transition.
+  //
+  // IiPpPpI                   -> (PPPPPPP)  (pending, pending, pending, pending, pending, pending)
+  // IiPpPpIiPpPpI             -> (PPPPPPPPPPPPP)
+  // IiPpPpIiPpPpIiPpPpI       -> (PPPPPPPPPPPPPPPPPPP)
+  // IiPpPpIiPpPpIiPpPpIiPpPpI -> (PPPPPPPPPPPPPPPPPPPPPPPPP)
+  //
+  // pending_nalus = 7 + 13 + 19 + 25 = 64
+  const struct validation_stats expected = {.unsigned_gops = 4,
+      .pending_nalus = 64,
+      .has_no_timestamp = true,
+      .final_validation = &final_validation};
+
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Check authentication if public key arrives late and a sei is missing before public key arrives.
+ *
+ * The operation is as follows:
+ * 1. Generate a nalu_list with a sequence of signed GOPs.
+ * 2. Check the sequence of NAL Units.
+ * 3. Remove the first GOP containing the public key.
+ * 4. Remove a sei before public key arrives.
+ * 5. Check the authentication result.
+ */
+START_TEST(late_public_key_and_no_sei_before_key_arrives)
+{
+  test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPIPPIPPI", settings[_i]);
+
+  ck_assert(list);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSIPPSIPPSI");
+
+  test_stream_item_t *g_1 = test_stream_item_remove(list, 5);
+  test_stream_item_check_type(g_1, 'S');
+  test_stream_check_types(list, "SIPPIPPSIPPSIPPSIPPSIPPSI");
+  // First public key now exist in item 8 if SV_RECURRENCE_EIGHT and SV_RECURRENCE_OFFSET_THREE
+
+  // Final validation is NOT OK and all received NAL Units, but the last one, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_NOT_OK, false, 25, 24, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {.valid_gops = 5,
+      .invalid_gops = 2,
+      .pending_nalus = 10,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_item_free(g_1);
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Add some NAL Units to a stream, where the last one is super long. Too long for
+ * SV_AUTHENTICITY_LEVEL_FRAME to handle it. Note that in tests we run with a shorter max hash list
+ * size, namely 10; See meson file.
+ *
+ * With
+ *   IPPIPPPPPPPPPPPPPPPPPPPPPPPPI
+ *
+ * we automatically fall back on SV_AUTHENTICITY_LEVEL_GOP in at the third 'I'.
+ */
+START_TEST(fallback_to_gop_level)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  const size_t kFallbackSize = 10;
+  signed_video_t *sv =
+      get_initialized_signed_video(settings[_i].codec, settings[_i].generate_key, false);
+  ck_assert(sv);
+  ck_assert_int_eq(signed_video_set_authenticity_level(sv, settings[_i].auth_level), SV_OK);
+  // If the true hash size is different from the default one, the test should still pass.
+  ck_assert_int_eq(set_hash_list_size(sv->gop_info, kFallbackSize * DEFAULT_HASH_SIZE), SV_OK);
+
+  // Create a list of NAL Units given the input string.
+  test_stream_t *list = create_signed_nalus_with_sv(sv, "IPPIPPPPPPPPPPPPPPPPPPPPPPPPIPPI", false);
+  test_stream_check_types(list, "SIPPSIPPPPPPPPPPPPPPPPPPPPPPPPSIPPSI");
+
+  // Final validation is OK and all received NAL Units, but the last one, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 36, 35, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {
+      .valid_gops = 4, .pending_nalus = 4, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+  signed_video_free(sv);
+}
+END_TEST
+
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+/* Test description
+ * APIs in vendors/axis-communications are used and tests both signing and validation parts. */
+START_TEST(vendor_axis_communications_operation)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  SignedVideoReturnCode sv_rc;
+  SignedVideoCodec codec = settings[_i].codec;
+  SignedVideoAuthenticityLevel auth_level = settings[_i].auth_level;
+  test_stream_item_t *i_nalu = test_stream_item_create_from_type('I', 0, codec);
+  test_stream_item_t *sei_item = NULL;
+  char *private_key = NULL;
+  size_t private_key_size = 0;
+  size_t sei_size = 0;
+
+  // Check generate private key.
+  signed_video_t *sv = signed_video_create(codec);
+  ck_assert(sv);
+  // Read and set content of private_key.
+  sv_rc = settings[_i].generate_key(NULL, &private_key, &private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Check setting attestation report.
+  const size_t attestation_size = 2;
+  void *attestation = calloc(1, attestation_size);
+  // Setting |attestation| and |certificate_chain|.
+  sv_rc = sv_vendor_axis_communications_set_attestation_report(
+      sv, attestation, attestation_size, axisDummyCertificateChain);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  free(attestation);
+
+  sv_rc = signed_video_set_product_info(sv, HW_ID, FW_VER, NULL, "Axis Communications AB", ADDR);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Setting validation level.
+  sv_rc = signed_video_set_authenticity_level(sv, auth_level);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Add an 'I' to trigger a SEI.
+  sv_rc = signed_video_add_nalu_for_signing(sv, i_nalu->data, i_nalu->data_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  ck_assert(sei_size > 0);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  uint8_t *sei = malloc(sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sei_item = test_stream_item_create(sei, sei_size, codec);
+  ck_assert(tag_is_present(sei_item, codec, VENDOR_AXIS_COMMUNICATIONS_TAG));
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(sei_size == 0);
+
+  signed_video_free(sv);
+  free(private_key);
+
+  // End of signing side. Start a new session on the validation side.
+  sv = signed_video_create(codec);
+  ck_assert(sv);
+
+  // Validate this first GOP.
+  signed_video_authenticity_t *auth_report = NULL;
+  signed_video_latest_validation_t *latest = NULL;
+
+  sv_rc =
+      signed_video_add_nalu_and_authenticate(sv, sei_item->data, sei_item->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(!auth_report);
+  sv_rc = signed_video_add_nalu_and_authenticate(sv, i_nalu->data, i_nalu->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  if (auth_report) {
+    latest = &(auth_report->latest_validation);
+    ck_assert(latest);
+    ck_assert_int_eq(strcmp(latest->validation_str, ".P"), 0);
+    ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_OK);
+    ck_assert_int_eq(auth_report->accumulated_validation.authenticity, SV_AUTH_RESULT_OK);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_has_changed, false);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_received_nalus, 2);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_validated_nalus, 1);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_pending_nalus, 1);
+    ck_assert_int_eq(
+        auth_report->accumulated_validation.public_key_validation, SV_PUBKEY_VALIDATION_NOT_OK);
+    // We are done with auth_report.
+    latest = NULL;
+    signed_video_authenticity_report_free(auth_report);
+  } else {
+    ck_assert(false);
+  }
+
+  // Free nalu_list_item and session.
+  test_stream_item_free(sei_item);
+  test_stream_item_free(i_nalu);
+  signed_video_free(sv);
+}
+END_TEST
+#endif
+
+static signed_video_t *
+generate_and_set_private_key_on_camera_side(struct sv_setting setting,
+    bool add_public_key_to_sei,
+    test_stream_item_t **sei_item)
+{
+  SignedVideoReturnCode sv_rc;
+  char *private_key = NULL;
+  size_t private_key_size = 0;
+  test_stream_item_t *i_nalu = test_stream_item_create_from_type('I', 0, setting.codec);
+  signed_video_t *sv = signed_video_create(setting.codec);
+  ck_assert(sv);
+  // Read and set content of private_key.
+  sv_rc = setting.generate_key(NULL, &private_key, &private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  sv_rc = signed_video_add_public_key_to_sei(sv, add_public_key_to_sei);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_authenticity_level(sv, setting.auth_level);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Add an 'I' to trigger a SEI.
+  sv_rc = signed_video_add_nalu_for_signing(sv, i_nalu->data, i_nalu->data_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  size_t sei_size = 0;
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  ck_assert(sei_size > 0);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  uint8_t *sei = malloc(sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  *sei_item = test_stream_item_create(sei, sei_size, setting.codec);
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(sei_size == 0);
+  ck_assert(tag_is_present(*sei_item, setting.codec, PUBLIC_KEY_TAG) == add_public_key_to_sei);
+
+  test_stream_item_free(i_nalu);
+  free(private_key);
+  return sv;
+}
+
+static void
+validate_public_key_scenario(signed_video_t *sv,
+    test_stream_item_t *sei,
+    bool wrong_key,
+    pem_pkey_t *public_key)
+{
+  SignedVideoReturnCode sv_rc;
+  SignedVideoCodec codec = sv->codec;
+  bool public_key_present = sv->has_public_key;
+
+  // Validate this first GOP.
+  signed_video_authenticity_t *auth_report = NULL;
+  signed_video_latest_validation_t *latest = NULL;
+
+  test_stream_item_t *i_nalu = test_stream_item_create_from_type('I', 0, codec);
+  sv_rc = signed_video_add_nalu_and_authenticate(sv, sei->data, sei->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(!auth_report);
+
+  // Late public key
+  if (public_key) {
+    sv_rc = signed_video_set_public_key(sv, public_key->key, public_key->key_size);
+    ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
+    // Since setting a public key after the session start is not supported, there is no point in
+    // adding the i_nalu and authenticate.
+  } else {
+    sv_rc =
+        signed_video_add_nalu_and_authenticate(sv, i_nalu->data, i_nalu->data_size, &auth_report);
+
+    if (public_key_present) {
+      ck_assert_int_eq(sv_rc, SV_OK);
+    } else {
+      ck_assert_int_eq(sv_rc, SV_NOT_SUPPORTED);
+    }
+
+    if (public_key_present) {
+      ck_assert(auth_report);
+      latest = &(auth_report->latest_validation);
+      ck_assert(latest);
+      if (tag_is_present(sei, codec, PUBLIC_KEY_TAG)) {
+        // |public_key_has_changed| is true if another public key is added.
+        ck_assert(latest->public_key_has_changed == wrong_key);
+      }
+
+      if (wrong_key) {
+        ck_assert_int_eq(latest->authenticity, SV_AUTH_RESULT_NOT_OK);
+      } else {
+        ck_assert_int_eq(latest->authenticity, SV_AUTH_RESULT_OK);
+      }
+    }
+    // We are done with auth_report
+    signed_video_authenticity_report_free(auth_report);
+  }
+  // Free nalu_list_item and session.
+  test_stream_item_free(i_nalu);
+}
+
+/* Test description
+ * Check if the API signed_video_add_public_key_to_sei can add a public key to the SEI and if
+ * signed_video_add_public_key_to_sei can set a public key on the auth side.
+ *
+ * Verify that it is not valid to add a manipulated key or set a public key in the middle of a
+ * stream.
+ *
+ * Default is when a public key is added to the SEI.
+ */
+START_TEST(test_public_key_scenarios)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  struct pk_setting {
+    bool pk_in_sei;
+    bool use_wrong_pk;
+    bool set_pk_before_session_start;
+    bool set_pk_after_session_start;
+  };
+
+  struct pk_setting pk_tests[] = {
+      // No public key in SEI. The correct public key is added to Signed Video before starting the
+      // session.
+      {false, false, true, false},
+      // Public key present in SEI. The correct public key is also added to Signed Video before
+      // starting the session.
+      {true, false, true, false},
+      // No public key in SEI and no public key added to Signed Video.
+      {false, false, false, false},
+      // No public key in SEI. The correct public key is added to Signed Video after the session has
+      // started.
+      {false, false, false, true},
+      // Public key present in SEI. The correct public key is also added to Signed Video after the
+      // session has started.
+      {true, false, false, true},
+      // Public key present in SEI. A manipulated public key is also added to Signed Video before
+      // starting the session.
+      {true, true, true, false},
+      // Activate when TODO in the test below is fixed.
+      //    {false, true, false, true},
+  };
+
+  for (size_t j = 0; j < sizeof(pk_tests) / sizeof(*pk_tests); j++) {
+    SignedVideoReturnCode sv_rc;
+    SignedVideoCodec codec = settings[_i].codec;
+    test_stream_item_t *sei = NULL;
+    signed_video_t *sv_camera = NULL;
+    char *tmp_private_key = NULL;
+    size_t tmp_private_key_size = 0;
+    pem_pkey_t wrong_public_key = {0};
+
+    sv_camera =
+        generate_and_set_private_key_on_camera_side(settings[_i], pk_tests[j].pk_in_sei, &sei);
+
+    // On validation side
+    signed_video_t *sv_vms = signed_video_create(codec);
+
+    sign_or_verify_data_t sign_data_wrong_key = {0};
+    // Generate a new private key in order to extract a bad private key (a key not compatible with
+    // the one generated on the camera side)
+    settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
+    sv_rc = openssl_private_key_malloc(&sign_data_wrong_key, tmp_private_key, tmp_private_key_size);
+    ck_assert_int_eq(sv_rc, SV_OK);
+    openssl_read_pubkey_from_private_key(&sign_data_wrong_key, &wrong_public_key);
+
+    pem_pkey_t *public_key = &sv_camera->pem_public_key;
+    if (pk_tests[j].use_wrong_pk) {
+      public_key = &wrong_public_key;
+    }
+    if (pk_tests[j].set_pk_before_session_start) {
+      sv_rc = signed_video_set_public_key(sv_vms, public_key->key, public_key->key_size);
+      ck_assert_int_eq(sv_rc, SV_OK);
+    }
+    if (!pk_tests[j].set_pk_after_session_start) {
+      public_key = NULL;
+    }
+    validate_public_key_scenario(sv_vms, sei, pk_tests[j].use_wrong_pk, public_key);
+
+    signed_video_free(sv_camera);
+    signed_video_free(sv_vms);
+    free(tmp_private_key);
+    openssl_free_key(sign_data_wrong_key.key);
+    free(sign_data_wrong_key.signature);
+    free(wrong_public_key.key);
+    test_stream_item_free(sei);
+  }
+}
+END_TEST
+
+/* Test description */
+START_TEST(no_public_key_in_sei_and_bad_public_key_on_validation_side)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  SignedVideoReturnCode sv_rc;
+  SignedVideoCodec codec = settings[_i].codec;
+  test_stream_item_t *i_nalu = test_stream_item_create_from_type('I', 0, codec);
+  test_stream_item_t *sei = NULL;
+  signed_video_t *sv_camera = NULL;
+  char *tmp_private_key = NULL;
+  size_t tmp_private_key_size = 0;
+  pem_pkey_t wrong_public_key = {0};
+
+  // On camera side
+  sv_camera = generate_and_set_private_key_on_camera_side(settings[_i], false, &sei);
+
+  // On validation side
+  signed_video_t *sv_vms = signed_video_create(codec);
+
+  // Generate a new private key in order to extract a bad private key (a key not compatible with the
+  // one generated on the camera side)
+  sign_or_verify_data_t sign_data = {0};
+  settings[_i].generate_key(NULL, &tmp_private_key, &tmp_private_key_size);
+  sv_rc = openssl_private_key_malloc(&sign_data, tmp_private_key, tmp_private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  openssl_read_pubkey_from_private_key(&sign_data, &wrong_public_key);
+  // Set public key
+  sv_rc = signed_video_set_public_key(sv_vms, wrong_public_key.key, wrong_public_key.key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Validate this first GOP.
+  signed_video_authenticity_t *auth_report = NULL;
+
+  sv_rc = signed_video_add_nalu_and_authenticate(sv_vms, sei->data, sei->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(!auth_report);
+
+  sv_rc =
+      signed_video_add_nalu_and_authenticate(sv_vms, i_nalu->data, i_nalu->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // TODO: This test is correct but currently one I-frame is not enough. The state "signature
+  // present" will be used until the bug is fixed.
+  ck_assert_int_eq(auth_report->latest_validation.authenticity, SV_AUTH_RESULT_SIGNATURE_PRESENT);
+
+  signed_video_authenticity_report_free(auth_report);
+  // Free nalu_list_item and session.
+  test_stream_item_free(sei);
+  test_stream_item_free(i_nalu);
+  signed_video_free(sv_vms);
+  signed_video_free(sv_camera);
+  free(tmp_private_key);
+  openssl_free_key(sign_data.key);
+  free(sign_data.signature);
+  free(wrong_public_key.key);
+}
+END_TEST
+
+/* Test validation if emulation prevention bytes are added later, by for example an encoder.
+ * We only run the case where emulation prevention bytes are not added when writing the SEI, since
+ * the other case is the default and executed for all other tests. */
+START_TEST(no_emulation_prevention_bytes)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  SignedVideoCodec codec = settings[_i].codec;
+  SignedVideoReturnCode sv_rc;
+
+  // Create a video with a single I-frame, and a SEI (to be created later).
+  test_stream_item_t *i_nalu = test_stream_item_create_from_type('I', 0, codec);
+  test_stream_item_t *sei_item = NULL;
+
+  size_t sei_size;
+  // Signing side
+  // Generate a Private key.
+  char *private_key = NULL;
+  size_t private_key_size = 0;
+  sv_rc = settings[_i].generate_key(NULL, &private_key, &private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Create a session.
+  signed_video_t *sv = signed_video_create(codec);
+  ck_assert(sv);
+
+  // Apply settings to session.
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_sei_epb(sv, false);
+  ck_assert_int_eq(sv_rc, SV_OK);
+#ifdef SV_VENDOR_AXIS_COMMUNICATIONS
+  const size_t attestation_size = 2;
+  void *attestation = calloc(1, attestation_size);
+  // Setting |attestation| and |certificate_chain|.
+  sv_rc = sv_vendor_axis_communications_set_attestation_report(
+      sv, attestation, attestation_size, axisDummyCertificateChain);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  free(attestation);
+#endif
+
+  // Add I-frame for signing and get SEI frame.
+  sv_rc = signed_video_add_nalu_for_signing_with_timestamp(
+      sv, i_nalu->data, i_nalu->data_size, &g_testTimestamp);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  sv_rc = signed_video_get_sei(sv, NULL, &sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  uint8_t *sei = malloc(sei_size);
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+
+  ck_assert(sei_size != 0);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Allocate memory for a new buffer to write to, and add emulation prevention bytes.
+  uint8_t *sei_with_epb = malloc(sei_size * 4 / 3);
+  uint8_t *sei_p = sei_with_epb;
+  uint16_t last_two_bytes = LAST_TWO_BYTES_INIT_VALUE;
+  memcpy(sei_p, sei, 4);
+  sei_p += 4;  // Move past the start code to avoid an incorrect emulation prevention byte.
+  char *src = (char *)(sei + 4);
+  size_t src_size = sei_size - 4;
+  write_byte_many(&sei_p, src, src_size, &last_two_bytes, true);
+  size_t sei_with_epb_size = sei_p - sei_with_epb;
+  signed_video_nalu_data_free(sei);
+
+  // Create a SEI.
+  sei_item = test_stream_item_create(sei_with_epb, sei_with_epb_size, codec);
+
+  sv_rc = signed_video_get_sei(sv, sei, &sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(sei_size == 0);
+
+  // Close signing side.
+  signed_video_free(sv);
+  sv = NULL;
+
+  // End of signing side. Start a new session on the validation side.
+  sv = signed_video_create(codec);
+  ck_assert(sv);
+
+  // Validate this first GOP.
+  signed_video_authenticity_t *auth_report = NULL;
+  signed_video_latest_validation_t *latest = NULL;
+
+  // Assume we receive a single AU with a SEI and an 'I'.
+  // Pass in the SEI.
+  sv_rc =
+      signed_video_add_nalu_and_authenticate(sv, sei_item->data, sei_item->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  ck_assert(!auth_report);
+  // Pass in the I-frame.
+  sv_rc = signed_video_add_nalu_and_authenticate(sv, i_nalu->data, i_nalu->data_size, &auth_report);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  // Read the authenticity report.
+  if (auth_report) {
+    latest = &(auth_report->latest_validation);
+    ck_assert(latest);
+    ck_assert_int_eq(strcmp(latest->validation_str, ".P"), 0);
+    // Public key validation is not feasible since there is no Product information.
+    ck_assert_int_eq(latest->public_key_validation, SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
+    ck_assert_int_eq(auth_report->accumulated_validation.authenticity, SV_AUTH_RESULT_OK);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_has_changed, false);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_received_nalus, 2);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_validated_nalus, 1);
+    ck_assert_int_eq(auth_report->accumulated_validation.number_of_pending_nalus, 1);
+    ck_assert_int_eq(auth_report->accumulated_validation.public_key_validation,
+        SV_PUBKEY_VALIDATION_NOT_FEASIBLE);
+    // We are done with auth_report.
+    latest = NULL;
+    signed_video_authenticity_report_free(auth_report);
+    auth_report = NULL;
+  } else {
+    ck_assert(false);
+  }
+
+  // End of validation, free memory.
+  test_stream_item_free(sei_item);
+  test_stream_item_free(i_nalu);
+  signed_video_free(sv);
+  free(private_key);
+}
+END_TEST
+
+/* Test description
+ * Add
+ *   IPPIPPIPPIPPIPPIP
+ * Then after ideal signing it becomes
+ *   SIPPSIPPSIPPSIPPSIPPSIP
+ * Assume it take one frame to sign
+ *   ISPPISPPISPPISPPISPPISP
+ * Assume the second signing event takes 7 frames
+ *   ISPPIPPIPPISPSPSISPPISP
+ *
+ * This test generates a stream with six SEIs and move them in time to simulate a signing
+ * delay.
+ */
+START_TEST(with_blocked_signing)
+{
+  // This test runs in a loop with loop index _i, corresponding to struct sv_setting _i in
+  // |settings|; See signed_video_helpers.h.
+
+  test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPIPPIP", settings[_i]);
+  test_stream_check_types(list, "SIPPSIPPSIPPSIPPSIPPSIP");
+  test_stream_item_t *sei = test_stream_item_remove(list, 21);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 21);
+  sei = test_stream_item_remove(list, 17);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 17);
+  sei = test_stream_item_remove(list, 13);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 15);
+  sei = test_stream_item_remove(list, 9);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 13);
+  sei = test_stream_item_remove(list, 5);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 11);
+  sei = test_stream_item_remove(list, 1);
+  test_stream_item_check_type(sei, 'S');
+  test_stream_append_item(list, sei, 1);
+  test_stream_check_types(list, "ISPPIPPIPPISPSPSISPPISP");
+
+  // Expected validation result
+  //   IS                      -> P.                     (1 pending)
+  //   ISPPIPPIPPIS            -> ....PPPPPPP.           (7 pending)
+  //       IPPIPPISPS          ->     ...PPPP.P.         (5 pending)
+  //          IPPISPSPS        ->        ...P.P.P.       (3 pending)
+  //             ISPSPSIS      ->           ......P.     (1 pending)
+  //                   ISPPISP ->                 ....P. (1 pending)
+  //                                                   = 18 pending
+  // The last P is never validated since it was never signed.
+  // It only appears in the final report.
+  struct validation_stats expected = {.valid_gops = 6, .pending_nalus = 18};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+}
+END_TEST
+
+/* Test description
+ * Generates SEIs using golden SEI prinsiple and verifies them.
+ * The operation is as follows:
+ * 1. Generate and store golden SEI
+ * 2. Enable golden SEI principle
+ * 3. Create a test stream.
+ * 4. Insert golden SEI to test stream
+ * 5. Validate the test stream
+ */
+START_TEST(golden_sei_principle)
+{
+  if (settings[_i].auth_level != SV_AUTHENTICITY_LEVEL_FRAME) return;
+
+  SignedVideoCodec codec = settings[_i].codec;
+  SignedVideoReturnCode sv_rc;
+  char *private_key = NULL;
+  size_t private_key_size = 0;
+  // Setup the key
+  sv_rc = settings[_i].generate_key(NULL, &private_key, &private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  // Generate golden SEI
+  signed_video_t *sv = signed_video_create(codec);
+  ck_assert(sv);
+
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_hash_algo(sv, settings[_i].hash_algo_name);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_product_info(sv, HW_ID, FW_VER, SER_NO, MANUFACT, ADDR);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_generate_golden_sei(sv);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  size_t golden_sei_size = 0;
+  sv_rc = signed_video_get_sei(sv, NULL, &golden_sei_size);
+  ck_assert(golden_sei_size != 0);
+  uint8_t *golden_sei = malloc(golden_sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  // Store the |golden_sei|
+  sv_rc = signed_video_get_sei(sv, golden_sei, &golden_sei_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  test_stream_item_t *golden_sei_item = test_stream_item_create(golden_sei, golden_sei_size, codec);
+  // End the |sv| session
+  signed_video_free(sv);
+
+  // Start a new stream
+  sv = signed_video_create(codec);
+  ck_assert(sv);
+  sv_rc = signed_video_set_using_golden_sei(sv, true);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_authenticity_level(sv, settings[_i].auth_level);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_private_key_new(sv, private_key, private_key_size);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_hash_algo(sv, settings[_i].hash_algo_name);
+  ck_assert_int_eq(sv_rc, SV_OK);
+  sv_rc = signed_video_set_product_info(sv, HW_ID, FW_VER, SER_NO, MANUFACT, ADDR);
+  ck_assert_int_eq(sv_rc, SV_OK);
+
+  test_stream_t *list = create_signed_nalus_with_sv(sv, "IPPIPPIPPI", false);
+  test_stream_prepend_first_item(list, golden_sei_item);
+  test_stream_check_types(list, "SSIPPSIPPSIPPSI");
+  signed_video_free(sv);
+  // Final validation is OK and all received NAL Units, but the last one, are validated.
+  signed_video_accumulated_validation_t final_validation = {
+      SV_AUTH_RESULT_OK, false, 15, 14, 1, SV_PUBKEY_VALIDATION_NOT_FEASIBLE, true, 0, 0};
+  // One pending NAL Unit per GOP.
+  struct validation_stats expected = {.valid_gops = 4,
+      .pending_nalus = 4,
+      .has_signature = 1,
+      .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected);
+
+  test_stream_free(list);
+  free(private_key);
+}
+END_TEST
+
+#endif
+
 static Suite *
 onvif_media_signing_validator_suite(void)
 {
@@ -92,6 +2280,44 @@ onvif_media_signing_validator_suite(void)
 
   // Add tests
   tcase_add_loop_test(tc, invalid_api_inputs, s, e);
+  // tcase_add_loop_test(tc, intact_stream, s, e);
+  // tcase_add_loop_test(tc, intact_multislice_stream, s, e);
+  // tcase_add_loop_test(tc, intact_stream_with_splitted_nalus, s, e);
+  // tcase_add_loop_test(tc, intact_stream_with_pps_nalu_stream, s, e);
+  // tcase_add_loop_test(tc, intact_stream_with_pps_bytestream, s, e);
+  // tcase_add_loop_test(tc, intact_ms_stream_with_pps_nalu_stream, s, e);
+  // tcase_add_loop_test(tc, intact_ms_stream_with_pps_bytestream, s, e);
+  // tcase_add_loop_test(tc, intact_with_undefined_nalu_in_stream, s, e);
+  // tcase_add_loop_test(tc, intact_with_undefined_multislice_nalu_in_stream, s, e);
+  // tcase_add_loop_test(tc, remove_one_p_nalu, s, e);
+  // tcase_add_loop_test(tc, interchange_two_p_nalus, s, e);
+  // tcase_add_loop_test(tc, modify_one_p_nalu, s, e);
+  // tcase_add_loop_test(tc, modify_one_i_nalu, s, e);
+  // tcase_add_loop_test(tc, remove_the_g_nalu, s, e);
+  // tcase_add_loop_test(tc, remove_the_i_nalu, s, e);
+  // tcase_add_loop_test(tc, remove_the_gi_nalus, s, e);
+  // tcase_add_loop_test(tc, sei_arrives_late, s, e);
+  // tcase_add_loop_test(tc, all_seis_arrive_late, s, e);
+  // tcase_add_loop_test(tc, all_seis_arrive_late_first_gop_scrapped, s, e);
+  // tcase_add_loop_test(tc, lost_g_before_late_sei_arrival, s, e);
+  // tcase_add_loop_test(tc, lost_g_and_gop_with_late_sei_arrival, s, e);
+  // tcase_add_loop_test(tc, lost_all_nalus_between_two_seis, s, e);
+  // tcase_add_loop_test(tc, add_one_sei_nalu_after_signing, s, e);
+  // tcase_add_loop_test(tc, camera_reset_on_signing_side, s, e);
+  // tcase_add_loop_test(tc, detect_change_of_public_key, s, e);
+  // tcase_add_loop_test(tc, fast_forward_stream_with_reset, s, e);
+  // tcase_add_loop_test(tc, fast_forward_stream_without_reset, s, e);
+  // tcase_add_loop_test(tc, fast_forward_stream_with_delayed_seis, s, e);
+  // tcase_add_loop_test(tc, file_export_with_dangling_end, s, e);
+  // tcase_add_loop_test(tc, file_export_without_dangling_end, s, e);
+  // tcase_add_loop_test(tc, no_signature, s, e);
+  // tcase_add_loop_test(tc, multislice_no_signature, s, e);
+  // tcase_add_loop_test(tc, late_public_key_and_no_sei_before_key_arrives, s, e);
+  // tcase_add_loop_test(tc, test_public_key_scenarios, s, e);
+  // tcase_add_loop_test(tc, no_public_key_in_sei_and_bad_public_key_on_validation_side,
+  // s, e); tcase_add_loop_test(tc, fallback_to_gop_level, s, e); tcase_add_loop_test(tc,
+  // golden_sei_principle, s, e); tcase_add_loop_test(tc, no_emulation_prevention_bytes,
+  // s, e); tcase_add_loop_test(tc, with_blocked_signing, s, e);
 
   // Add test case to suit
   suite_add_tcase(suite, tc);


### PR DESCRIPTION
Adds all validator test code, but commented out.
Adds all validator code, but only the defintion of the public
API is used. The rest is commented out.
