### PR TITLE
Adds signature verification in register_nalu

### DIFF
--- a/lib/src/oms_openssl.c
+++ b/lib/src/oms_openssl.c
@@ -294,12 +294,12 @@ openssl_sign_hash(sign_or_verify_data_t *sign_data)
   return status;
 }
 
-#if 0
 /* Verifies the |signature|. */
 oms_rc
 openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result)
 {
-  if (!verify_data || !verified_result) return OMS_INVALID_PARAMETER;
+  if (!verify_data || !verified_result)
+    return OMS_INVALID_PARAMETER;
 
   int verified_hash = -1;  // Initialize to 'error'.
 
@@ -310,11 +310,13 @@ openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_resu
 
   oms_rc status = OMS_UNKNOWN_FAILURE;
   OMS_TRY()
-    OMS_THROW_IF(!signature || signature_size == 0 || !hash_to_verify, OMS_INVALID_PARAMETER);
+    OMS_THROW_IF(
+        !signature || signature_size == 0 || !hash_to_verify, OMS_INVALID_PARAMETER);
     EVP_PKEY_CTX *ctx = (EVP_PKEY_CTX *)verify_data->key;
     OMS_THROW_IF(!ctx, OMS_INVALID_PARAMETER);
     // EVP_PKEY_verify returns 1 upon success, 0 upon failure and < 0 upon error.
-    verified_hash = EVP_PKEY_verify(ctx, signature, signature_size, hash_to_verify, hash_size);
+    verified_hash =
+        EVP_PKEY_verify(ctx, signature, signature_size, hash_to_verify, hash_size);
   OMS_CATCH()
   OMS_DONE(status)
 
@@ -322,7 +324,6 @@ openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_resu
 
   return status;
 }
-#endif
 
 /* Hashes the data using |hash_algo.type|. */
 oms_rc

--- a/lib/src/oms_openssl_internal.h
+++ b/lib/src/oms_openssl_internal.h
@@ -98,6 +98,22 @@ MediaSigningReturnCode
 openssl_sign_hash(sign_or_verify_data_t *sign_data);
 
 /**
+ * @brief Verifies a signature against a hash
+ *
+ * The |hash| is verified against the |signature| using the public |key|, all being
+ * members of the input parameter |verify_data|.
+ *
+ * @param verify_data Pointer to the sign_or_verify_data_t object in use.
+ * @param verified_result Poiniter to the place where the verification result is written.
+ *   The |verified_result| can either be 1 (success), 0 (failure), or < 0 (error).
+ *
+ * @returns OMS_OK Successfully generated |signature|,
+ *          OMS_INVALID_PARAMETER Errors in |verify_data|, or null pointer inputs,
+ */
+oms_rc
+openssl_verify_hash(const sign_or_verify_data_t *verify_data, int *verified_result);
+
+/**
  * @brief Turns a private key on PEM form to EVP_PKEY form
  *
  * and allocates memory for a signature

--- a/lib/src/oms_tlv.h
+++ b/lib/src/oms_tlv.h
@@ -117,7 +117,6 @@ oms_rc
 tlv_decode(onvif_media_signing_t *self, const uint8_t *data, size_t data_size);
 #endif
 
-#if 0
 /**
  * @brief Scans the TLV part of a SEI payload and decodes all recurrent tags
  *
@@ -135,7 +134,6 @@ bool
 tlv_find_and_decode_optional_tags(onvif_media_signing_t *self,
     const uint8_t *tlv_data,
     size_t tlv_data_size);
-#endif
 
 /**
  * @brief Scans the TLV part of a SEI payload and stops when a given tag is detected.


### PR DESCRIPTION
As soon as a SEI is detected it can be verified. Further, all
optional data can be decoded and stored, like the public key and
hash algorithm.
