### PR TITLE
Verifies signature right after receiving it from plugin

### DIFF
--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -80,11 +80,13 @@ update_hash(onvif_media_signing_t *self,
     const nalu_info_t *nalu_info,
     uint8_t *hash,
     size_t hash_size);
+#ifndef ONVIF_MEDIA_SIGNING_DEBUG
 static oms_rc
 simply_hash(onvif_media_signing_t *self,
     const nalu_info_t *nalu_info,
     uint8_t *hash,
     size_t hash_size);
+#endif
 static oms_rc
 hash_and_copy_to_anchor(onvif_media_signing_t *self,
     const nalu_info_t *nalu_info,
@@ -972,7 +974,11 @@ update_hash(onvif_media_signing_t *self,
  *
  * takes the |hashable_data| from the NAL Unit, hash it and stores the hash in
  * |nalu_hash|. */
+#ifdef ONVIF_MEDIA_SIGNING_DEBUG
+oms_rc
+#else
 static oms_rc
+#endif
 simply_hash(onvif_media_signing_t *self,
     const nalu_info_t *nalu_info,
     uint8_t *hash,

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -386,6 +386,16 @@ nalu_type_to_str(const nalu_info_t *nalu);
 char
 nalu_type_to_char(const nalu_info_t *nalu_info);
 
+#ifdef ONVIF_MEDIA_SIGNING_DEBUG
+oms_rc
+simply_hash(onvif_media_signing_t *self,
+    const nalu_info_t *nalu_info,
+    uint8_t *hash,
+    size_t hash_size);
+void
+update_hashable_data(nalu_info_t *nalu_info);
+#endif
+
 #if 0
 /* Sets the allowed size of |hash_list|.
  * Note that this can be different from what is allocated. */


### PR DESCRIPTION
Only applies under debugprint. The SEI is hashed and then the
signature is verified. This works for any number of pending
SEIs.
