### PR TITLE
Adds tests for Golden SEI

### DIFF
--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -205,6 +205,7 @@ typedef struct _validation_flags_t {
                          // performed.
   bool is_first_sei;  // Indicates that this is the first received SEI.
   bool hash_algo_known;  // Information on what hash algorithm to use has been received.
+  bool validate_golden_sei;  // Golden SEIs should be validated stand alone.
 } validation_flags_t;
 
 #ifdef VALIDATION_SIDE


### PR DESCRIPTION
Testing both a Golden SEI as first frame and as header to the
second one. Special actions when validating has been taken, since
Golden SEIs are self-signed and should be validated independently
and as soon as possible.
