### PR TITLE
Adds a test to verify validation when multiple GOPs are signed

### DIFF
--- a/lib/src/oms_authenticity_report.c
+++ b/lib/src/oms_authenticity_report.c
@@ -237,7 +237,7 @@ static void
 update_accumulated_validation(const onvif_media_signing_latest_validation_t *latest,
     onvif_media_signing_accumulated_validation_t *accumulated)
 {
-  if (accumulated->authenticity == OMS_NOT_SIGNED) {
+  if (accumulated->authenticity <= OMS_AUTHENTICITY_NOT_FEASIBLE) {
     // Still either pending validation or video has no signature. Update with the result
     // from |latest|.
     accumulated->authenticity = latest->authenticity;

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -166,6 +166,7 @@ struct _nalu_list_item_t {
   //       invalid NAL Unit.
   // 'E' : An error occurred and validation could not be performed. This should be treated
   //       as an invalid NAL Unit.
+  char validation_status_if_sei_ok;
   uint8_t hash[MAX_HASH_SIZE];  // The hash of the NAL Unit is stored in this memory slot,
   // if it is hashable that is.
 #if 0
@@ -179,7 +180,7 @@ struct _nalu_list_item_t {
   bool first_verification_not_authentic;  // Marks the NALU as not authentic so the second one does
   // not overwrite with an acceptable status.
 #endif
-  bool used_in_gop_hash;  // Marks the NAL Unit as being part of a computed |gop_hash|.
+  nalu_list_item_t *associated_sei;  // Which SEI this item is associated with.
   bool has_been_decoded;  // Marks a SEI as decoded. Decoding it twice might overwrite
   // vital information.
   int verified_signature;
@@ -206,6 +207,7 @@ typedef struct _validation_flags_t {
   bool is_first_sei;  // Indicates that this is the first received SEI.
   bool hash_algo_known;  // Information on what hash algorithm to use has been received.
   bool validate_golden_sei;  // Golden SEIs should be validated stand alone.
+  bool waiting_for_signature;  // Validating a GOP with a SEI without signature.
 } validation_flags_t;
 
 #ifdef VALIDATION_SIDE

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -589,7 +589,7 @@ START_TEST(signing_multiple_gops)
   // |settings|; See test_helpers.h.
 
   struct oms_setting setting = settings[_i];
-  // Select an upper payload limit which is less then the size of the last SEI.
+  // Select a signing frequency longer than every GOP
   const unsigned signing_frequency = 2;
   setting.signing_frequency = signing_frequency;
   test_stream_t *list = create_signed_nalus("IPPIPPIPPIPPIP", setting);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -42,6 +42,17 @@
 
 const int64_t g_testTimestamp = 133620480301234567;  // 08:00:30.1234567 UTC June 5, 2024
 
+// struct oms_setting {
+//   MediaSigningCodec codec;
+//   generate_key_fcn_t generate_key;
+//   const char* hash_algo;
+//   bool low_bitrate_mode;
+//   bool ep_before_signing;
+//   size_t max_sei_payload_size;
+//   bool with_golden_sei;
+//   unsigned max_signing_nalus;
+//   unsigned signing_frequency;
+// };
 struct oms_setting settings[NUM_SETTINGS] = {
     {OMS_CODEC_H264, EC_KEY, NULL, false, false, 0, false, 0, 1},
     {OMS_CODEC_H265, EC_KEY, NULL, false, false, 0, false, 0, 1},


### PR DESCRIPTION
Flag for marking items used in gop_hash now rely on the
associated SEI instead. Further, when the SEI with a signature
has successfully been validated, the previous GOPs are
recursively marked.
