### PR TITLE
Adds a provenance member to authenticity report

### DIFF
--- a/examples/apps/validator/main.c
+++ b/examples/apps/validator/main.c
@@ -239,7 +239,6 @@ on_new_sample_from_sink(GstElement *elt, ValidationData *data)
           strcat(result, VALIDATION_VALID);
           break;
         case OMS_AUTHENTICITY_NOT_OK:
-        case OMS_PROVENANCE_NOT_OK:
           data->invalid_gops++;
           strcat(result, VALIDATION_INVALID);
           break;
@@ -344,10 +343,11 @@ on_source_message(GstBus __attribute__((unused)) * bus,
       }
       fprintf(f, "-----------------------------\n");
       if (data->auth_report) {
-        if (data->auth_report->accumulated_validation.authenticity ==
+        if (data->auth_report->accumulated_validation.provenance ==
             OMS_PROVENANCE_NOT_OK) {
           fprintf(f, "PUBLIC KEY IS NOT VALID!\n");
-        } else if (!data->auth_report->accumulated_validation.public_key_has_changed) {
+        } else if (data->auth_report->accumulated_validation.provenance ==
+            OMS_PROVENANCE_OK) {
           fprintf(f, "PUBLIC KEY IS VALID!\n");
         } else {
           fprintf(f, "PUBLIC KEY COULD NOT BE VALIDATED!\n");

--- a/lib/src/oms_validator.c
+++ b/lib/src/oms_validator.c
@@ -82,7 +82,7 @@ verify_hashes_without_sei(onvif_media_signing_t *self);
 
 #ifdef ONVIF_MEDIA_SIGNING_DEBUG
 const char *kAuthResultValidStr[OMS_AUTHENTICITY_NUM_STATES] = {
-    "MEDIA SIGNING NOT PRESENT", "MEDIA SIGNING PRESENT", "PROVENANCE NOT OK", "NOT OK",
+    "MEDIA SIGNING NOT PRESENT", "MEDIA SIGNING PRESENT", "NOT OK",
     "OK WITH MISSING INFO", "OK", "VERSION MISMATCH"};
 #endif
 


### PR DESCRIPTION
This separates the provenance from the authenticity of the video.
Strictly, a video can be authentic (untampered) even for fake
videos, but the provenance (signed with a specific device) is
not.
