### PR TITLE
Updates READMEs with documentations on example applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ cryptographic signatures to the video. Each video frame is hashed and signatures
 generated repeatedly based on these hashes, using a private key set by the signer. The
 signature data added to the video does not affect the video rendering. The data is added
 in a Supplemental Enhancement Information (SEI) NAL Unit of type "user data unregistered".
-This SEI has a UUID of `005bc93f-2d71-5e95-ada4-796f90877a6f` in hexadecimal.
+This SEI has a UUID of `005bc93f-2d71-5e95-ada4-796f90877a6f` (in hexadecimal).
 
 For a more detailed description of the ONVIF Media Signing feature see the specification
 TODO: ADD REFERENCE TO SPECIFICATION.
@@ -41,7 +41,7 @@ both a threaded and an unthreaded signing plugin.
 
 For instructions on how to use the APIs to integrate the ONVIF Media Signing Framework in
 either a signing or a validation application, see [lib/](./lib/). Example applications are
-available in [plugins](./lib/examples/).
+available in [examples](./examples/).
 
 # Releases
 There are no pre-built releases. The user is encouraged to build the library from a
@@ -116,7 +116,6 @@ ninja -C build test
 Alternatively, you can run the script
 [tests/test_checks.sh](./tests/test_checks.sh) and the unittests will run both with and
 without debug prints. Note that you need libcheck installed as well.
-TODO: ADD TEST SCRIPT
 
 # License
 [MIT License](./LICENSE)

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,7 +20,8 @@ Below is a list of example applications available in the repository.
 - [signer](./apps/signer/)
   - The example code implements video signing.
 - [validator](./apps/validator/)
-  - The example code implements video authenticity validation.
+  - The example code implements video authenticity validation by continuously validating
+    the authenticity and provenance of a video file.
 
 ### Building applications
 The applications in this repository all have meson options for easy usage. These options
@@ -41,4 +42,4 @@ meson install -C build_apps
 The executable is now located at `./my_installs/bin/<application>`
 
 ## Example files
-Shorter MP4 recordings for testing can be found in [examples/test-files/](./examples/test-files/).
+Shorter MP4 recordings for testing can be found in [test-files/](./test-files/).

--- a/examples/apps/signer/README.md
+++ b/examples/apps/signer/README.md
@@ -5,7 +5,7 @@ Note: This example application code also serves as example code for how to imple
 signing side of the *Signed Media Framework*.
 
 ## Prerequisites
-This application relies on gStreamer and signed-media-framework.
+This application relies on gStreamer.
 - [gStreamer](https://gstreamer.freedesktop.org/documentation/installing/index.html?gi-language=c)
 
 ## Description

--- a/lib/plugins/README.md
+++ b/lib/plugins/README.md
@@ -4,12 +4,12 @@
 
 Signing using a private key is usually done in a secure part of a device. This usually
 requires device specific operations which cannot be generalized to an open source project.
-Therefore, there the framework supports signing through a concept of plugins.
+Therefore, the framework supports signing through a concept of plugins.
 
 The ONVIF Signed Media Framework comes with implementations of two plugins;
 [unthreaded-signing/plugin.c](./unthreaded-signing/plugin.c) and
 [threaded-signing/plugin.c](./threaded-signing/plugin.c). Both of them use OpenSSL APIs
-to generate signatures. TODO: FILES TO BE ADDED WHEN INTERFACES ARE SET
+to generate signatures.
 
 It is safe to use any of these plugins in a multi-threaded integration.
 

--- a/lib/src/README.md
+++ b/lib/src/README.md
@@ -8,33 +8,33 @@ part. All public APIs needed are located in [includes/](./includes/).
 The APIs needed are
 [onvif_media_signing_common.h](./includes/onvif_media_signing_common.h) and
 [onvif_media_signing_validator.h](./includes/onvif_media_signing_validator.h).
-To validate a H264 or H265 video you need to split the video into NAL Units. For a
+To validate an H.264 or an H.265 video you need to split the video into NAL Units. For a
 detailed description and example code see
 [onvif_media_signing_validator.h](./includes/onvif_media_signing_validator.h) or look at
-the validator in the
-[signed-media-framework-examples](https://github.com/onvif/signed-media-framework-examples)
-repository. TODO: TO BE CREATED
+the validator application in the
+[examples/apps/validator](../../examples/apps/validator/).
 
 ## Making your own signing application
 The APIs needed are
-[onvif_media_signing_common.h](./includes/onvif_media_signing_common.h) and
-[onvif_media_signing_signer.h](./includes/onvif_media_signing_signer.h).
-To sign a H264 or H265 video you need to split the video into NAL Units. Before signing
-can begin you need to configure the ONVIF Media Signing session. Setting a private key is
-mandatory, but there are also possibilities to add some product information etc. to use.
-The public key, needed for validation, is automatically added to the stream through its
-certificate chain.
+[onvif_media_signing_common.h](./includes/onvif_media_signing_common.h),
+[onvif_media_signing_signer.h](./includes/onvif_media_signing_signer.h) and
+[onvif_media_signing_signer.h](./includes/onvif_media_signing_plugin.h).
+To sign an H.264 or an H.265 video you need to split the video into NAL Units. Before
+signing can begin you need to configure the ONVIF Media Signing session. Setting a private
+key is mandatory, but there are also possibilities to add some product information etc. to
+use. The public key, needed for validation, is automatically added to the stream through
+its certificate chain.
 
 The ONVIF Signed Media Framework generates SEI frames including signatures and other
 information. Getting them and instructions on how to add them to the current stream are
 handled through the API `onvif_media_signing_get_sei()`. Note that the framework follows
-the Access Unit format of H264, hence SEI frames must prepend the NAL Unit slices.
+the Access Unit format of H.264, hence SEI frames must prepend the NAL Unit slices.
 
 For a detailed description and example code see
 [onvif_media_signing_signer.h](./includes/onvif_media_signing_signer.h) or look at the
-signer in the
-[signed-media-framework-examples](https://github.com/onvif/signed-media-framework-examples)
-repository.
+signer application in the
+[examples/apps/signer](../../examples/apps/signer/) where signing is implemented as a
+gStreamer element.
 
 ## Making your own signing plugin
 There is no signing plugin management in the ONVIF Signed Media Framework. It currently

--- a/test_apps.sh
+++ b/test_apps.sh
@@ -41,5 +41,5 @@ cat validation_results.txt
 
 cp examples/test-files/test_h265.mp4 .
 $SIGNER -c h265 test_h265.mp4
-$VALIDATOR -c h265 signed_test_h265.mp4
+$VALIDATOR -b -c h265 signed_test_h265.mp4
 cat validation_results.txt


### PR DESCRIPTION
Also adds a bulk mode when running the validator, which does not
handle intermediate validations. Instead, relies completely on
the accumulated authenticity report.
