### PR TITLE
Adds timestamp to authenticity reports

### DIFF
--- a/lib/src/oms_authenticity_report.c
+++ b/lib/src/oms_authenticity_report.c
@@ -198,7 +198,7 @@ latest_validation_init(onvif_media_signing_latest_validation_t *self)
   self->number_of_expected_hashable_nalus = -1;
   self->number_of_received_hashable_nalus = -1;
   self->number_of_pending_hashable_nalus = 0;
-  self->timestamp = 0;
+  self->timestamp = -1;
 
   free(self->nalu_str);
   self->nalu_str = NULL;
@@ -220,8 +220,8 @@ accumulated_validation_init(onvif_media_signing_accumulated_validation_t *self)
   self->number_of_received_nalus = 0;
   self->number_of_validated_nalus = 0;
   self->number_of_pending_nalus = 0;
-  self->first_timestamp = 0;
-  self->last_timestamp = 0;
+  self->first_timestamp = -1;
+  self->last_timestamp = -1;
 }
 
 static void
@@ -272,14 +272,11 @@ update_accumulated_validation(const onvif_media_signing_latest_validation_t *lat
   // }
 
   // Update timestamps if possible.
-  // if (latest->has_timestamp) {
-  //   if (!accumulated->has_timestamp) {
-  //     // No previous timestamp has been set.
-  //     accumulated->first_timestamp = latest->timestamp;
-  //   }
-  //   accumulated->last_timestamp = latest->timestamp;
-  //   accumulated->has_timestamp = true;
-  // }
+  if (accumulated->first_timestamp < 0) {
+    // No previous timestamp has been set.
+    accumulated->first_timestamp = latest->timestamp;
+  }
+  accumulated->last_timestamp = latest->timestamp;
 }
 
 void

--- a/lib/src/oms_tlv.c
+++ b/lib/src/oms_tlv.c
@@ -287,7 +287,7 @@ decode_general(onvif_media_signing_t *self, const uint8_t *data, size_t data_siz
     bytes_to_version_str(self->code_version, code_version_str);
     // Read timestamp
     data_ptr += read_64bits_signed(data_ptr, &gop_info->timestamp);
-    // self->latest_validation->timestamp = gop_info->timestamp;
+    self->latest_validation->timestamp = gop_info->timestamp;
     // Read current GOP
     data_ptr += read_32bits(data_ptr, &gop_info->current_gop);
     DEBUG_LOG("Found GOP counter = %u", gop_info->current_gop);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -211,6 +211,7 @@ create_signed_nalus_with_oms(onvif_media_signing_t *oms,
   // Create a test stream given the input string.
   test_stream_t *list = test_stream_create(str, oms->codec);
   test_stream_item_t *item = list->first_item;
+  int64_t timestamp = g_testTimestamp;
 
   // Loop through the NAL Units and add for signing.
   while (item) {
@@ -223,15 +224,16 @@ create_signed_nalus_with_oms(onvif_media_signing_t *oms,
       // Split the NAL Unit into 2 parts, where the last part inlcudes the ID and the stop
       // bit.
       rc = onvif_media_signing_add_nalu_part_for_signing(
-          oms, item->data, item->data_size - 2, g_testTimestamp, false);
+          oms, item->data, item->data_size - 2, timestamp, false);
       ck_assert_int_eq(rc, OMS_OK);
       rc = onvif_media_signing_add_nalu_part_for_signing(
-          oms, &item->data[item->data_size - 2], 2, g_testTimestamp, true);
+          oms, &item->data[item->data_size - 2], 2, timestamp, true);
     } else {
       rc = onvif_media_signing_add_nalu_part_for_signing(
-          oms, item->data, item->data_size, g_testTimestamp, true);
+          oms, item->data, item->data_size, timestamp, true);
     }
     ck_assert_int_eq(rc, OMS_OK);
+    timestamp += 400000;  // One frame if 25 fps.
 
     if (item->next == NULL) {
       break;


### PR DESCRIPTION
The tests now increment the timestamp for each frame and the
validation now tests the timestamps.
