### PR TITLE
Adds support for validating lost P-frames

### DIFF
--- a/lib/src/oms_nalu_list.h
+++ b/lib/src/oms_nalu_list.h
@@ -89,32 +89,34 @@ nalu_list_append(nalu_list_t* list, const nalu_info_t* nalu);
  *
  * @param list The list of which the last item is to be copied.
  *
- * @returns Signed Video Internal Return Code
+ * @returns Media Signing Return Code
  */
 oms_rc
 nalu_list_copy_last_item(nalu_list_t* list, bool hash_algo_known);
 
-#if 0
 /**
  * @brief Appends or prepends a certain item of a list with a new item marked as missing
  *
- * Searches through the |list| for the |item| and if found appends/prepends it with a new item that
- * is marked as missing (|validation_status| = 'M'). The |nalu| of this missing item is a NULL
- * pointer.
+ * Searches through the |list| for the |item| and if found appends/prepends it with a new
+ * item that is marked as missing (|validation_status| = 'M'). The |nalu| of this missing
+ * item is a NULL pointer.
  *
  * @param list The |list| including the |item|.
  * @param num_missing Number of missing items to append/prepend.
  * @param append Appends |item| if true and prepends |item| if false.
  * @param item The |item| of which the 'missing' items are append/prepend.
+ * @param associated_sei A pointer to the SEI which the missing items are associated with.
  *
- * @returns Signed Video Internal Return Code
+ * @returns Media Signing Return Code
  */
 oms_rc
-h26x_nalu_list_add_missing(nalu_list_t* list,
+nalu_list_add_missing_items(nalu_list_t* list,
     int num_missing,
     bool append,
-    nalu_list_item_t* item);
+    nalu_list_item_t* item,
+    const nalu_list_item_t* associated_sei);
 
+#if 0
 /**
  * @brief Removes 'M' items present at the beginning of a |list|
  *

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -337,10 +337,14 @@ create_signed_nalus_int(const char __attribute__((unused)) * str,
 /* Removes the NAL Unit item with position |item_number| from the test stream |list|. The
  * item is, after a check against the expected |type|, then freed. */
 void
-remove_item_then_check_and_free(test_stream_t __attribute__((unused)) * list,
-    int __attribute__((unused)) item_number,
-    char __attribute__((unused)) type)
+remove_item_then_check_and_free(test_stream_t *list, int item_number, char type)
 {
+  if (!list) {
+    return;
+  }
+  test_stream_item_t *item = test_stream_item_remove(list, item_number);
+  test_stream_item_check_type(item, type);
+  test_stream_item_free(item);
 }
 
 /* Modifies the id of |item_number| by incrementing the value by one. A sanity check on


### PR DESCRIPTION
Validating a video with lost P-frames is now supported. When
verifying the gop hash fails, individual hashes are checked, if
a hash list exists in the SEI that is.
Tests for normal operation as well as signig partial and multiple
gops have been added.

In addition, the multiple gop test now is set to sign every third
GOP, which better exercise the recursive parts of the code.
