### PR TITLE
Adds one byte to communicate partial GOP

### DIFF
--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -1083,7 +1083,7 @@ hash_with_anchor(onvif_media_signing_t *self,
         self->crypto_handle, gop_info->hash_buddies, hash_size * 2, buddy_hash));
     // Copy |buddy_hash| to |linked_hash| queue if signing is triggered. Only applies on
     // the signing side.
-    if (nalu_info->triggered_signing && !self->authentication_started) {
+    if (gop_info->triggered_partial_gop && !self->authentication_started) {
       update_linked_hash(self, buddy_hash, hash_size);
     }
   OMS_CATCH()

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -127,7 +127,6 @@ typedef struct _nalu_t {
   bool is_last_nalu_part;  // True if the |nalu_data| includes the last part
   bool with_epb;  // Hashable data may include emulation prevention bytes
   bool is_certificate_sei;
-  bool triggered_signing;  // True if GOP is long enough to trigger an intermediate SEI
   bool is_signed;  // True if the SEI is signed, i.e., has a signature
 } nalu_info_t;
 
@@ -357,6 +356,8 @@ struct _gop_info_t {
   uint32_t current_partial_gop;  // The index of the current partial GOP (current SEI).
   uint32_t next_partial_gop;  // The index of the next partial GOP (when decoding SEI).
 
+  bool triggered_partial_gop;  // Marks if the signing was triggered by an intermediate
+                               // partial GOP, compared to normal I-frame triggered.
   bool global_gop_counter_is_synced;  // Turns true when a SEI corresponding to the
                                       // segment is detected.
   int verified_signature;  // Status of last hash-signature-pair verification. Has 1 for


### PR DESCRIPTION
To make life easy for the validation side, one flag to signal
that current signing was triggered by a P-frame instead of an
I-frame has been added.
