### PR TITLE
Applies emulation prevention on SEI

### DIFF
--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -433,7 +433,8 @@ START_TEST(get_seis_in_correct_order)
       get_initialized_media_signing_by_setting(settings[_i], false);
   ck_assert(oms);
 
-  test_stream_t *list = create_signed_nalus_with_oms(oms, "IIPPIP", false, true);
+  test_stream_t *list = create_signed_nalus_with_oms(
+      oms, "IIPPIP", false, true, !settings[_i].ep_before_signing);
   test_stream_check_types(list, "IIPPISSP");
   verify_seis(list, settings[_i]);
 
@@ -470,7 +471,8 @@ START_TEST(start_stream_with_certificate_sei)
   omsrc = onvif_media_signing_generate_certificate_sei(oms);
   ck_assert_int_eq(omsrc, OMS_OK);
 
-  test_stream_t *list = create_signed_nalus_with_oms(oms, "IPPIPPPIP", false, false);
+  test_stream_t *list = create_signed_nalus_with_oms(
+      oms, "IPPIPPPIP", false, false, !setting.ep_before_signing);
   test_stream_check_types(list, "GIPPISPPPISP");
   verify_seis(list, setting);
   test_stream_free(list);
@@ -512,7 +514,7 @@ START_TEST(w_wo_emulation_prevention_bytes)
     onvif_media_signing_t *oms = get_initialized_media_signing_by_setting(setting, false);
     ck_assert(oms);
 
-    test_stream_t *list = create_signed_nalus_with_oms(oms, "IIP", false, true);
+    test_stream_t *list = create_signed_nalus_with_oms(oms, "IIP", false, true, false);
     test_stream_check_types(list, "IISP");
     verify_seis(list, setting);
 

--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -2126,7 +2126,8 @@ START_TEST(certificate_sei_first)
   omsrc = onvif_media_signing_generate_certificate_sei(oms);
   ck_assert_int_eq(omsrc, OMS_OK);
 
-  test_stream_t *list = create_signed_nalus_with_oms(oms, "IPPIPPPIPPPIP", false, false);
+  test_stream_t *list = create_signed_nalus_with_oms(
+      oms, "IPPIPPPIPPPIP", false, false, !setting.ep_before_signing);
   onvif_media_signing_free(oms);
   test_stream_check_types(list, "GIPPISPPPISPPPISP");
 
@@ -2168,7 +2169,8 @@ START_TEST(certificate_sei_later)
   omsrc = onvif_media_signing_generate_certificate_sei(oms);
   ck_assert_int_eq(omsrc, OMS_OK);
 
-  test_stream_t *list = create_signed_nalus_with_oms(oms, "IPPIPPPIPPPIP", false, false);
+  test_stream_t *list = create_signed_nalus_with_oms(
+      oms, "IPPIPPPIPPPIP", false, false, !setting.ep_before_signing);
   onvif_media_signing_free(oms);
   test_stream_check_types(list, "GIPPISPPPISPPPISP");
   test_stream_item_t *certificate_sei = test_stream_pop_first_item(list);

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -114,7 +114,8 @@ test_stream_t*
 create_signed_nalus_with_oms(onvif_media_signing_t* oms,
     const char* str,
     bool split_nalus,
-    bool get_seis_at_end);
+    bool get_seis_at_end,
+    bool apply_ep);
 
 /* Removes the NAL Unit item with position |item_number| from the test stream |list|. The
  * item is, after a check against the expected |type|, then freed. */


### PR DESCRIPTION
If the SEI was not hashed with emulation prevention, those bytes
are added afterwards in tests when fetching them from the lib.
