### PR TITLE
Solves correct link when signing partial gops

### DIFF
--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -476,8 +476,11 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
     // Determine if a SEI should be generated.
     unsigned hashed_nalus = gop_info->hash_list_idx / self->sign_data->hash_size;
     bool new_gop = (nalu_info.is_first_nalu_in_gop && nalu_info.is_last_nalu_part);
+    // Trigger signing if number of hashes exceeds the limit.
     bool trigger_signing =
         (self->max_signing_nalus > 0 && hashed_nalus >= self->max_signing_nalus);
+    // Only trigger if this NAL Unit is hashable, hence will be added to the hash list.
+    trigger_signing &= nalu_info.is_hashable;
     gop_info->triggered_partial_gop = false;
     // Depending on the input NAL Unit, different actions are taken. If the input is an
     // I-frame there is a transition to a new GOP. That triggers generating a SEI. While

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -434,7 +434,7 @@ START_TEST(get_seis_in_correct_order)
   ck_assert(oms);
 
   test_stream_t *list = create_signed_nalus_with_oms(
-      oms, "IIPPIP", false, true, !settings[_i].ep_before_signing);
+      oms, "IIPPIP", false, true, !settings[_i].ep_before_signing, 0);
   test_stream_check_types(list, "IIPPISSP");
   verify_seis(list, settings[_i]);
 
@@ -472,7 +472,7 @@ START_TEST(start_stream_with_certificate_sei)
   ck_assert_int_eq(omsrc, OMS_OK);
 
   test_stream_t *list = create_signed_nalus_with_oms(
-      oms, "IPPIPPPIP", false, false, !setting.ep_before_signing);
+      oms, "IPPIPPPIP", false, false, !setting.ep_before_signing, 0);
   test_stream_check_types(list, "CIPPISPPPISP");
   verify_seis(list, setting);
   test_stream_free(list);
@@ -514,7 +514,7 @@ START_TEST(w_wo_emulation_prevention_bytes)
     onvif_media_signing_t *oms = get_initialized_media_signing_by_setting(setting, false);
     ck_assert(oms);
 
-    test_stream_t *list = create_signed_nalus_with_oms(oms, "IIP", false, true, false);
+    test_stream_t *list = create_signed_nalus_with_oms(oms, "IIP", false, true, false, 0);
     test_stream_check_types(list, "IISP");
     verify_seis(list, setting);
 

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -50,6 +50,7 @@ struct oms_setting {
   bool with_certificate_sei;
   unsigned max_signing_nalus;
   unsigned signing_frequency;
+  int delay;
 };
 
 #define NUM_SETTINGS 10
@@ -115,7 +116,8 @@ create_signed_nalus_with_oms(onvif_media_signing_t* oms,
     const char* str,
     bool split_nalus,
     bool get_seis_at_end,
-    bool apply_ep);
+    bool apply_ep,
+    int delay);
 
 /* Removes the NAL Unit item with position |item_number| from the test stream |list|. The
  * item is, after a check against the expected |type|, then freed. */


### PR DESCRIPTION
If signing was triggered by a SEI, which is not added to the hash
list, the link hash was never updated and the same link was used
twice. This commit fixes that.

Tests for validating scenarios when SEIs are delayed and partial
or multiple GOPs are signed has been added. The delay is added at
the signing side instead of moving items afterwards, which
reflects the true behavior of threaded signing.
