### PR TITLE
Adds get_seis_at_end to oms_setting structure

### DIFF
--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -399,19 +399,16 @@ END_TEST
  * Note that this only applies when low bitrate mode is disabled. */
 START_TEST(get_seis_in_correct_order)
 {
+  struct oms_setting setting = settings[_i];
   // By test construction, cannot be run in low bitrate mode.
-  if (settings[_i].low_bitrate_mode) {
+  if (setting.low_bitrate_mode) {
     return;
   }
 
-  onvif_media_signing_t *oms =
-      get_initialized_media_signing_by_setting(settings[_i], false);
-  ck_assert(oms);
-
-  test_stream_t *list = create_signed_nalus_with_oms(
-      oms, "IIPPIP", false, true, !settings[_i].ep_before_signing, 0);
+  setting.get_seis_at_end = true;
+  test_stream_t *list = create_signed_nalus("IIPPIP", setting);
   test_stream_check_types(list, "IIPPISSP");
-  verify_seis(list, settings[_i]);
+  verify_seis(list, setting);
 
   // Analyze SEIs in order.
   size_t sei_sizes[2] = {0};
@@ -425,7 +422,6 @@ START_TEST(get_seis_in_correct_order)
   ck_assert_int_lt(sei_sizes[0], sei_sizes[1]);
 
   test_stream_free(list);
-  onvif_media_signing_free(oms);
 }
 END_TEST
 

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -53,19 +53,20 @@ static unsigned int delay_until_pull = 0;
 //   unsigned max_signing_nalus;
 //   unsigned signing_frequency;
 //   int delay;
+//   bool get_seis_at_end;
 // };
 struct oms_setting settings[NUM_SETTINGS] = {
-    {OMS_CODEC_H264, true, NULL, false, false, 0, false, 0, 1, 0},
-    {OMS_CODEC_H265, true, NULL, false, false, 0, false, 0, 1, 0},
-    {OMS_CODEC_H264, true, NULL, true, false, 0, false, 0, 1, 0},
-    {OMS_CODEC_H265, true, NULL, true, false, 0, false, 0, 1, 0},
-    {OMS_CODEC_H264, true, NULL, false, true, 0, false, 0, 1, 0},
-    {OMS_CODEC_H265, true, NULL, false, true, 0, false, 0, 1, 0},
-    {OMS_CODEC_H264, true, NULL, true, true, 0, false, 0, 1, 0},
-    {OMS_CODEC_H265, true, NULL, true, true, 0, false, 0, 1, 0},
+    {OMS_CODEC_H264, true, NULL, false, false, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H265, true, NULL, false, false, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H264, true, NULL, true, false, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H265, true, NULL, true, false, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H264, true, NULL, false, true, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H265, true, NULL, false, true, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H264, true, NULL, true, true, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H265, true, NULL, true, true, 0, false, 0, 1, 0, false},
     // Special cases
-    {OMS_CODEC_H264, true, "sha512", false, true, 0, false, 0, 1, 0},
-    {OMS_CODEC_H264, false, NULL, false, false, 0, false, 0, 1, 0},
+    {OMS_CODEC_H264, true, "sha512", false, true, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H264, false, NULL, false, false, 0, false, 0, 1, 0, false},
 };
 
 static char private_key_ec[EC_PRIVATE_KEY_ALLOC_BYTES];
@@ -332,8 +333,8 @@ create_signed_splitted_nalus_int(const char *str,
 
   // Create a test stream of NAL Units given the input string.
   bool apply_ep = !setting.ep_before_signing;
-  test_stream_t *list =
-      create_signed_nalus_with_oms(oms, str, split_nalus, false, apply_ep, setting.delay);
+  test_stream_t *list = create_signed_nalus_with_oms(
+      oms, str, split_nalus, setting.get_seis_at_end, apply_ep, setting.delay);
   onvif_media_signing_free(oms);
 
   return list;

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -51,6 +51,7 @@ struct oms_setting {
   unsigned max_signing_nalus;
   unsigned signing_frequency;
   int delay;
+  bool get_seis_at_end;
 };
 
 #define NUM_SETTINGS 10


### PR DESCRIPTION
This means that one can, through settings, select to pull the SEIs
once at the end instead of as soon as they are generated.
