### PR TITLE
Adds force no emulation prevention flag to oms_setting

### DIFF
--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -454,16 +454,14 @@ END_TEST
  * emulation prevention bytes. */
 START_TEST(w_wo_emulation_prevention_bytes)
 {
-  struct oms_setting setting = settings[_i];
   size_t sei_sizes[2] = {0, 0};
   bool with_emulation_prevention[2] = {true, false};
+  struct oms_setting setting = settings[_i];
+  setting.force_no_ep = true;
 
   for (size_t ii = 0; ii < 2; ii++) {
     setting.ep_before_signing = with_emulation_prevention[ii];
-    onvif_media_signing_t *oms = get_initialized_media_signing_by_setting(setting, false);
-    ck_assert(oms);
-
-    test_stream_t *list = create_signed_nalus_with_oms(oms, "IIP", false, true, false, 0);
+    test_stream_t *list = create_signed_nalus("IIP", setting);
     test_stream_check_types(list, "IISP");
     verify_seis(list, setting);
 
@@ -472,7 +470,6 @@ START_TEST(w_wo_emulation_prevention_bytes)
     sei_sizes[ii] = sei->data_size;
     test_stream_item_free(sei);
     test_stream_free(list);
-    onvif_media_signing_free(oms);
   }
 
   // Verify that the SEI sizes differ. By construction, the first SEI will include

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -54,19 +54,20 @@ static unsigned int delay_until_pull = 0;
 //   unsigned signing_frequency;
 //   int delay;
 //   bool get_seis_at_end;
+//   bool force_no_ep;
 // };
 struct oms_setting settings[NUM_SETTINGS] = {
-    {OMS_CODEC_H264, true, NULL, false, false, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H265, true, NULL, false, false, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H264, true, NULL, true, false, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H265, true, NULL, true, false, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H264, true, NULL, false, true, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H265, true, NULL, false, true, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H264, true, NULL, true, true, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H265, true, NULL, true, true, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H264, true, NULL, false, false, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H265, true, NULL, false, false, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H264, true, NULL, true, false, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H265, true, NULL, true, false, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H264, true, NULL, false, true, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H265, true, NULL, false, true, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H264, true, NULL, true, true, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H265, true, NULL, true, true, 0, false, 0, 1, 0, false, false},
     // Special cases
-    {OMS_CODEC_H264, true, "sha512", false, true, 0, false, 0, 1, 0, false},
-    {OMS_CODEC_H264, false, NULL, false, false, 0, false, 0, 1, 0, false},
+    {OMS_CODEC_H264, true, "sha512", false, true, 0, false, 0, 1, 0, false, false},
+    {OMS_CODEC_H264, false, NULL, false, false, 0, false, 0, 1, 0, false, false},
 };
 
 static char private_key_ec[EC_PRIVATE_KEY_ALLOC_BYTES];
@@ -332,7 +333,7 @@ create_signed_splitted_nalus_int(const char *str,
   }
 
   // Create a test stream of NAL Units given the input string.
-  bool apply_ep = !setting.ep_before_signing;
+  bool apply_ep = !setting.ep_before_signing && !setting.force_no_ep;
   test_stream_t *list = create_signed_nalus_with_oms(
       oms, str, split_nalus, setting.get_seis_at_end, apply_ep, setting.delay);
   onvif_media_signing_free(oms);

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -52,6 +52,7 @@ struct oms_setting {
   unsigned signing_frequency;
   int delay;
   bool get_seis_at_end;
+  bool force_no_ep;
 };
 
 #define NUM_SETTINGS 10


### PR DESCRIPTION
This means that emulation prevention is not applied to the SEI
and the output becomes what has been set when generating the SEI.
