### PR TITLE
Structures oms_internal.h

### DIFF
--- a/lib/plugins/unthreaded-signing/plugin.c
+++ b/lib/plugins/unthreaded-signing/plugin.c
@@ -33,15 +33,8 @@
 #include <stdlib.h>  // calloc, memcpy
 
 #include "includes/onvif_media_signing_plugin.h"
+#include "oms_defines.h"
 #include "oms_openssl_internal.h"
-
-#ifndef ATTR_UNUSED
-#if defined(_WIN32) || defined(_WIN64)
-#define ATTR_UNUSED
-#else
-#define ATTR_UNUSED __attribute__((unused))
-#endif
-#endif
 
 #define MAX_BUFFER_LENGTH 6
 // Structure for the output buffer of signatures

--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -48,6 +48,7 @@
 // nal_unit_type
 #define H265_NALU_HEADER_LEN 2  // length of nal_unit_header as per
 // ISO/ITU spec
+#define STOP_BYTE_VALUE 0x80
 
 static bool
 version_str_to_bytes(int *arr, const char *str);

--- a/lib/src/oms_defines.h
+++ b/lib/src/oms_defines.h
@@ -29,21 +29,48 @@
 #define __OMS_DEFINES_H__
 
 #include <stdbool.h>  // bool
+#if defined(ONVIF_MEDIA_SIGNING_DEBUG) || defined(PRINT_DECODED_SEI)
+#include <stdio.h>
+#endif
 
 #include "includes/onvif_media_signing_common.h"
 
 typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Return Code
 
+#ifndef ATTR_UNUSED
+#if defined(_WIN32) || defined(_WIN64)
+#define ATTR_UNUSED
+#else
+#define ATTR_UNUSED __attribute__((unused))
+#endif
+#endif
+
+#define OMS_VERSION_BYTES 3
+#define ONVIF_MEDIA_SIGNING_VERSION "v0.0.4"
+#define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
+
+// Maximum number of ongoing and completed SEIs to hold until the user fetches them
+#define MAX_SEI_DATA_BUFFER 60
 #define USER_DATA_UNREGISTERED 0x05
+#define UUID_LEN 16
+#define LAST_TWO_BYTES_INIT_VALUE 0x0101  // Anything but 0x00 are proper init values
+
+// Compile time defined, otherwise set default value
+#define DEFAULT_MAX_NUM_HASHES 300
+#ifndef MAX_NUM_HASHES
+#define MAX_NUM_HASHES DEFAULT_MAX_NUM_HASHES
+#endif
+
+// Currently the largest supported hash is SHA-512.
+#define MAX_HASH_SIZE (512 / 8)
+// Size of the default hash (SHA-256).
+#define DEFAULT_HASH_SIZE (256 / 8)
+#define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_NUM_HASHES)
 
 // Semicolon needed after, ex. DEBUG_LOG("my debug: %d", 42);
 #ifdef ONVIF_MEDIA_SIGNING_DEBUG
-#include <stdio.h>
 #define DEBUG_LOG(str, ...) printf("[DEBUG](%s): " str "\n", __func__, ##__VA_ARGS__)
 #else
-#ifdef PRINT_DECODED_SEI
-#include <stdio.h>
-#endif
 #define DEBUG_LOG(str, ...) ((void)0)
 #endif
 

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -34,52 +34,12 @@
 
 #include "includes/onvif_media_signing_common.h"  // MediaSigningReturnCode, onvif_media_signing_product_info_t
 #include "includes/onvif_media_signing_validator.h"
-#include "oms_defines.h"  // oms_rc
+#include "oms_defines.h"
 #include "oms_openssl_internal.h"  // pem_pkey_t, sign_or_verify_data_t
 
-typedef struct _gop_info_t gop_info_t;
-typedef struct _sei_data_t sei_data_t;
-typedef struct _nalu_list_item_t nalu_list_item_t;
-// typedef struct _validation_flags_t validation_flags_t;
-#ifdef VALIDATION_SIDE
-typedef struct _gop_state_t gop_state_t;
-#endif
-// Forward declare nalu_list_t here for onvif_media_signing_t.
-// typedef struct _nalu_list_t nalu_list_t;
-
-#if defined(_WIN32) || defined(_WIN64)
-#define ATTR_UNUSED
-#else
-#define ATTR_UNUSED __attribute__((unused))
-#endif
-
-#define OMS_VERSION_BYTES 3
-#define ONVIF_MEDIA_SIGNING_VERSION "v0.0.4"
-#define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
-
-#define DEFAULT_MAX_GOP_LENGTH 300
-
-// Maximum number of ongoing and completed SEIs to hold until the user fetches them
-#define MAX_SEI_DATA_BUFFER 60
-#define UUID_LEN 16
-#define LAST_TWO_BYTES_INIT_VALUE 0x0101  // Anything but 0x00 are proper init values
-#define STOP_BYTE_VALUE 0x80
 extern const uint8_t kUuidMediaSigning[UUID_LEN];
 
-#ifndef ARRAY_SIZE
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
-#endif
-
-/* Compile time defined, otherwise set default value */
-#ifndef MAX_GOP_LENGTH
-#define MAX_GOP_LENGTH DEFAULT_MAX_GOP_LENGTH
-#endif
-
-// Currently the largest supported hash is SHA-512.
-#define MAX_HASH_SIZE (512 / 8)
-// Size of the default hash (SHA-256).
-#define DEFAULT_HASH_SIZE (256 / 8)
-#define HASH_LIST_SIZE (MAX_HASH_SIZE * MAX_GOP_LENGTH)
+typedef struct _nalu_list_item_t nalu_list_item_t;
 
 typedef enum {
   NALU_TYPE_UNDEFINED = 0,
@@ -131,19 +91,6 @@ typedef struct _nalu_t {
 } nalu_info_t;
 
 /**
- * A struct representing the stream of NAL Units, added to Media Signing for validating
- * authenticity. It is a linked list of nalu_list_item_t and holds the first and last
- * items. The list is linear, that is, one parent and one child only.
- */
-typedef struct _nalu_list_t {
-  nalu_list_item_t *first_item;  // Points to the first item in the linked list, that is,
-                                 // the oldest NAL Unit added for validation.
-  nalu_list_item_t *last_item;  // Points to the last item in the linked list, that is,
-                                // the latest NAL Unit added for validation.
-  int num_items;  // The number of items linked together in the list.
-} nalu_list_t;
-
-/**
  * A struct representing a NAL Unit in a stream. The stream being a linked list. Each item
  * holds the NAL Unit data as well as pointers to the previous and next items in the list.
  */
@@ -151,8 +98,8 @@ struct _nalu_list_item_t {
   nalu_info_t *nalu_info;  // The parsed NAL Unit information.
   char validation_status;  // The authentication status which can take on the following
   // characters:
-  // 'P' : Pending validation. This is the initial value. The NALU has been registered and
-  //       waiting for validating the authenticity.
+  // 'P' : Pending validation. This is the initial value. The NAL Unit has been registered
+  //       and waiting for validating the authenticity.
   // 'U' : The NAL Unit has an unknown authenticity. This occurs if the NAL Unit could not
   //       be parsed, or ifthe SEI is associated with NAL Units not part of the validating
   //       segment.
@@ -168,17 +115,6 @@ struct _nalu_list_item_t {
   char validation_status_if_sei_ok;
   uint8_t hash[MAX_HASH_SIZE];  // The hash of the NAL Unit is stored in this memory slot,
   // if it is hashable that is.
-#if 0
-  size_t hash_size;
-  // Flags
-  bool taken_ownership_of_nalu;  // Flag to indicate if the item has taken ownership of the |nalu|
-  // memory, hence need to free the memory if the item is released.
-  bool need_second_verification;  // This NALU need another verification, either due to failures or
-  // because it is a chained hash, that is, used in two GOPs. The second verification is done with
-  // |second_hash|.
-  bool first_verification_not_authentic;  // Marks the NALU as not authentic so the second one does
-  // not overwrite with an acceptable status.
-#endif
   const nalu_list_item_t *associated_sei;  // Which SEI this item is associated with.
   bool has_been_decoded;  // Marks a SEI as decoded. Decoding it twice might overwrite
   // vital information.
@@ -190,6 +126,19 @@ struct _nalu_list_item_t {
   nalu_list_item_t *next;  // Points to the next added NAL Unit. Is NULL if this is the
   // last item.
 };
+
+/**
+ * A struct representing the stream of NAL Units, added to Media Signing for validating
+ * authenticity. It is a linked list of nalu_list_item_t and holds the first and last
+ * items. The list is linear, that is, one parent and one child only.
+ */
+typedef struct _nalu_list_t {
+  nalu_list_item_t *first_item;  // Points to the first item in the linked list, that is,
+                                 // the oldest NAL Unit added for validation.
+  nalu_list_item_t *last_item;  // Points to the last item in the linked list, that is,
+                                // the latest NAL Unit added for validation.
+  int num_items;  // The number of items linked together in the list.
+} nalu_list_t;
 
 typedef struct _validation_flags_t {
   bool has_auth_result;  // Indicates that an authenticity result is available for the
@@ -218,29 +167,54 @@ typedef struct _validation_flags_t {
                            // validation.
 } validation_flags_t;
 
-#ifdef VALIDATION_SIDE
-struct _gop_state_t {
-  bool has_sei;  // The GOP includes a SEI.
-  bool has_lost_sei;  // Has detected a lost SEI since last validation.
-  bool no_gop_end_before_sei;  // No GOP end (I-frame) has been found before the SEI.
-  bool gop_transition_is_lost;  // The transition between GOPs has been lost. This can be
-                                // detected if a lost SEI is detected, and at the same
-                                // time waiting for an 'I'. An example when this happens
-                                // is if an entire AU is lost including both the SEI and
-                                // the 'I'.
-};
-#endif
-
 // Buffer of |last_two_bytes| and pointers to |sei| memory and current |write_position|.
 // Writing of the SEI is split in time and it is therefore necessary to pick up the value
 // of |last_two_bytes| when we continue writing with emulation prevention turned on. As
 // soon as a SEI is completed, the |completed_sei_size| is filled in.
-struct _sei_data_t {
+typedef struct _sei_data_t {
   uint8_t *sei;  // Pointer to the allocated SEI data
   uint8_t *write_position;
   uint16_t last_two_bytes;
   size_t completed_sei_size;  // The final SEI size, set when it is completed
-};
+} sei_data_t;
+
+/**
+ * Information related to the GOP signature.
+ */
+typedef struct _gop_info_t {
+  uint8_t hash_buddies[2 * MAX_HASH_SIZE];  // Two hashes: [anchor_hash, nalu_hash].
+  bool has_anchor_hash;  // Flags if the anchor hash in |hash_buddies| is valid.
+  uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes
+  size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than
+                          // allocated.
+  int hash_list_idx;  // Pointing to next available slot in the |hash_list|. If something
+                      // has gone wrong, like exceeding available memory, |list_idx| = -1.
+  uint8_t *nalu_hash;  // Pointing to the NAL Unit hash in |hash_to_sign|.
+  uint8_t hash_to_sign[MAX_HASH_SIZE];  // Memory for storing the hash to be signed
+  uint8_t tmp_hash[MAX_HASH_SIZE];  // Memory for storing a temporary hash needed when a
+                                    // NAL Unit split in parts.
+  uint8_t partial_gop_hash[MAX_HASH_SIZE];  // Memory for storing a (partial) GOP hash.
+  uint8_t linked_hash[2 * MAX_HASH_SIZE];  // Memory for storing a linked hash and pending
+                                           // linked hash.
+  uint8_t encoding_status;  // Stores potential errors when encoding, to transmit to the
+                            // client (authentication part).
+  uint16_t num_sent_nalus;  // The number of NAL Units used to generate the gop_hash on
+                            // the signing side.
+  uint16_t num_nalus_in_partial_gop;  // Counted number of NAL Units in the currently
+                                      // recursively updated |gop_hash|.
+  int64_t current_partial_gop;  // The index of the current partial GOP (current SEI).
+  uint32_t next_partial_gop;  // The index of the next partial GOP (when decoding SEI).
+  uint32_t num_partial_gop_wraparounds;  // Tracks number of times the |next_partial_gop|
+                                         // has been wrapped around.
+
+  bool triggered_partial_gop;  // Marks if the signing was triggered by an intermediate
+                               // partial GOP, compared to normal I-frame triggered.
+  bool global_gop_counter_is_synced;  // Turns true when a SEI corresponding to the
+                                      // segment is detected.
+  int verified_signature;  // Status of last hash-signature-pair verification. Has 1 for
+                           // success, 0 for fail, and -1 for error.
+  int64_t timestamp;  // Unix epoch UTC timestamp of the first nalu in GOP
+} gop_info_t;
 
 struct _onvif_media_signing_t {
   // Members common to both signing and validation
@@ -315,59 +289,6 @@ struct _onvif_media_signing_t {
   uint8_t tmp_linked_hash[MAX_HASH_SIZE];  // Memory for storing a linked hash.
   uint16_t tmp_num_nalus_in_partial_gop;  // Counted number of NAL Units in the currently
                                           // recursively updated |gop_hash|.
-
-#ifdef VALIDATION_SIDE
-  // Members only used for validation
-  // TODO: Collect everything needed by the authentication part only in one struct/object,
-  // which then is not needed to be created on the signing side, saving some memory.
-
-  gop_state_t gop_state;
-  // For signature verification
-  pem_pkey_t pem_public_key;  // Public key in PEM form for writing/reading to/from SEIs
-
-#endif
-};
-
-/**
- * Information related to the GOP signature.
- * The |gop_hash| is a recursive hash. It is the hash of the memory [gop_hash, latest
- * hash] and then replaces the gop_hash location. This is used for signing, as it
- * incorporates all information of the nalus that has been added.
- */
-struct _gop_info_t {
-  uint8_t hash_buddies[2 *
-      MAX_HASH_SIZE];  // Memory for two hashes organized as [anchor_hash, nalu_hash].
-  bool has_anchor_hash;  // Flags if the anchor hash in |hash_buddies| is valid.
-  uint8_t hash_list[HASH_LIST_SIZE];  // Pointer to the list of hashes
-  size_t hash_list_size;  // The allowed size of the |hash_list|. This can be less than
-                          // allocated.
-  int hash_list_idx;  // Pointing to next available slot in the |hash_list|. If something
-                      // has gone wrong, like exceeding available memory, |list_idx| = -1.
-  uint8_t *nalu_hash;  // Pointing to the NAL Unit hash in |hash_to_sign|.
-  uint8_t hash_to_sign[MAX_HASH_SIZE];  // Memory for storing the hash to be signed
-  uint8_t tmp_hash[MAX_HASH_SIZE];  // Memory for storing a temporary hash needed when a
-                                    // NAL Unit split in parts.
-  uint8_t partial_gop_hash[MAX_HASH_SIZE];  // Memory for storing a (partial) GOP hash.
-  uint8_t linked_hash[2 * MAX_HASH_SIZE];  // Memory for storing a linked hash and pending
-                                           // linked hash.
-  uint8_t encoding_status;  // Stores potential errors when encoding, to transmit to the
-                            // client (authentication part).
-  uint16_t num_sent_nalus;  // The number of NAL Units used to generate the gop_hash on
-                            // the signing side.
-  uint16_t num_nalus_in_partial_gop;  // Counted number of NAL Units in the currently
-                                      // recursively updated |gop_hash|.
-  int64_t current_partial_gop;  // The index of the current partial GOP (current SEI).
-  uint32_t next_partial_gop;  // The index of the next partial GOP (when decoding SEI).
-  uint32_t num_partial_gop_wraparounds;  // Tracks number of times the |next_partial_gop|
-                                         // has been wrapped around.
-
-  bool triggered_partial_gop;  // Marks if the signing was triggered by an intermediate
-                               // partial GOP, compared to normal I-frame triggered.
-  bool global_gop_counter_is_synced;  // Turns true when a SEI corresponding to the
-                                      // segment is detected.
-  int verified_signature;  // Status of last hash-signature-pair verification. Has 1 for
-                           // success, 0 for fail, and -1 for error.
-  int64_t timestamp;  // Unix epoch UTC timestamp of the first nalu in GOP
 };
 
 /* Definitions in oms_common.c. */

--- a/lib/src/oms_tlv.c
+++ b/lib/src/oms_tlv.c
@@ -30,8 +30,13 @@
 #include <string.h>  // memcpy
 
 #include "oms_authenticity_report.h"  // transfer_vendor_info()
+#include "oms_defines.h"
 #include "oms_internal.h"  // gop_info_t
 #include "oms_openssl_internal.h"  // pem_pkey_t, sign_or_verify_data_t
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#endif
 
 /**
  * Encoder and decoder interfaces

--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -30,6 +30,7 @@
 
 #include "lib/src/includes/onvif_media_signing_common.h"
 #include "lib/src/includes/onvif_media_signing_validator.h"
+#include "lib/src/oms_defines.h"  // ATTR_UNUSED
 #include "lib/src/oms_internal.h"
 #include "test_helpers.h"
 


### PR DESCRIPTION
Removes dead code and organize stuctures to minimmize forward
declarations. Also moves common defines to oms_defines.h and
specific ones to respective c-file.
