### PR TITLE
The signer application can now handle absolute paths

### DIFF
--- a/test_apps.sh
+++ b/test_apps.sh
@@ -18,10 +18,6 @@ rm -rf build_validator
 rm -rf $GST_PLUGIN_PATH
 rm -rf $VALIDATOR_PATH
 # rm validation_results.txt
-# rm signed_test_h264.mp4
-# rm signed_test_h265.mp4
-# rm test_h264.mp4
-# rm test_h265.mp4
 
 echo ""
 echo "=== Build the signer example app ==="
@@ -38,19 +34,19 @@ echo ""
 meson setup -Dvalidator=true -Dbuildtype=debug -D$PARSESEI --prefix $VALIDATOR_PATH . build_validator
 meson install -C build_validator
 
-# Copy file to current directory
-cp examples/test-files/test_h264.mp4 .
-$VALIDATOR -c h264 test_h264.mp4
+# Sign and validate test files
+$VALIDATOR -c h264 examples/test-files/test_h264.mp4
 cat validation_results.txt
 
-$SIGNER -c h264 test_h264.mp4
-$VALIDATOR -C test -c h264 signed_test_h264.mp4
+$SIGNER -c h264 examples/test-files/test_h264.mp4
+$VALIDATOR -C test -c h264 examples/test-files/signed_test_h264.mp4
+cat validation_results.txt
+rm examples/test-files/signed_test_h264.mp4
+
+$VALIDATOR -b -c h265 examples/test-files/test_h265.mp4
 cat validation_results.txt
 
-cp examples/test-files/test_h265.mp4 .
-$VALIDATOR -b -c h265 test_h265.mp4
+$SIGNER -c h265 examples/test-files/test_h265.mp4
+$VALIDATOR -b -C test -c h265 examples/test-files/signed_test_h265.mp4
 cat validation_results.txt
-
-$SIGNER -c h265 test_h265.mp4
-$VALIDATOR -b -C test -c h265 signed_test_h265.mp4
-cat validation_results.txt
+rm examples/test-files/signed_test_h265.mp4


### PR DESCRIPTION
Further, the test_apps.sh script runs on test files without
copying them first.
