### PR TITLE
Improved prints when wrongly using example apps

### DIFF
--- a/examples/apps/signer/main.c
+++ b/examples/apps/signer/main.c
@@ -56,7 +56,7 @@
 
 /* Callback to get and read messages on the bus. */
 static gboolean
-bus_call(GstBus ATTR_UNUSED * bus, GstMessage *msg, gpointer data)
+bus_call(GstBus ATTR_UNUSED *bus, GstMessage *msg, gpointer data)
 {
   GMainLoop *loop = data;
 
@@ -116,9 +116,12 @@ main(gint argc, gchar *argv[])
   gchar *usage = g_strdup_printf(
       "Usage:\n%s [-h] [-c codec] filename\n\n"
       "Optional\n"
-      "  -c codec  : 'h264' (default) or 'h265'\n"
+      "  -h, --help       : This usage print.\n"
+      "  -c codec         : 'h264' (default if omitted) or 'h265'.\n"
       "Required\n"
-      "  filename  : Name of the file to be signed.\n",
+      "  filename         : Name of the file to be signed.\n"
+      "Output\n"
+      "  signed_filename  : Name of the file to be signed.\n",
       argv[0]);
 
   GError *error = NULL;
@@ -147,7 +150,7 @@ main(gint argc, gchar *argv[])
 
   // Parse options from command-line.
   while (arg < argc) {
-    if (strcmp(argv[arg], "-h") == 0) {
+    if ((strcmp(argv[arg], "-h") == 0) || (strcmp(argv[arg], "--help") == 0)) {
       g_message("\n%s\n", usage);
       status = 0;
       goto out_at_once;
@@ -157,6 +160,7 @@ main(gint argc, gchar *argv[])
     } else if (strncmp(argv[arg], "-", 1) == 0) {
       // Unknown option.
       g_message("Unknown option: %s\n%s", argv[arg], usage);
+      goto out_at_once;
     } else {
       // End of options.
       break;
@@ -164,6 +168,10 @@ main(gint argc, gchar *argv[])
     arg++;
   }
 
+  if (arg + 1 < argc) {
+    g_warning("options specified after filename\n%s", usage);
+    goto out;
+  }
   // Parse filename.
   if (arg < argc) {
     filename = argv[arg];

--- a/examples/apps/validator/main.c
+++ b/examples/apps/validator/main.c
@@ -448,12 +448,16 @@ main(int argc, char **argv)
   gchar *usage = g_strdup_printf(
       "Usage:\n%s [-h] [-b] [-c codec] [-C CAfilename] filename\n\n"
       "Optional\n"
-      "  -c codec      : 'h264' (default) or 'h265'\n"
-      "  -C CAfilename : location of the trusted CA to use and set. Name 'test' is "
-      "reserved.\n"
-      "  -b            : bulk validation, i.e., one single authenticity report at end\n"
+      "  -h, --help    : This usage print.\n"
+      "  -c codec      : 'h264' (default if omitted) or 'h265'.\n"
+      "  -C CAfilename : Location of the trusted CA to use and set. Name 'test' is "
+      "reserved and will get the test CA.\n"
+      "  -b            : Bulk validation, i.e., no intermediate validation results. "
+      "Instead one single authenticity report at end\n"
       "Required\n"
-      "  filename  : Name of the file to be validated.\n",
+      "  filename      : Name of the file to be validated.\n"
+      "Output\n"
+      "  text file     : A validation report is written to validation_results.txt.\n",
       argv[0]);
 
   // Initialization.
@@ -464,7 +468,7 @@ main(int argc, char **argv)
 
   // Parse options from command-line.
   while (arg < argc) {
-    if (strcmp(argv[arg], "-h") == 0) {
+    if ((strcmp(argv[arg], "-h") == 0) || (strcmp(argv[arg], "--help") == 0)) {
       g_message("\n%s\n", usage);
       status = 0;
       goto out;
@@ -479,6 +483,7 @@ main(int argc, char **argv)
     } else if (strncmp(argv[arg], "-", 1) == 0) {
       // Unknown option.
       g_message("Unknown option: %s\n%s", argv[arg], usage);
+      goto out;
     } else {
       // End of options.
       break;
@@ -487,6 +492,10 @@ main(int argc, char **argv)
   }
 
   // Parse filename.
+  if (arg + 1 < argc) {
+    g_warning("options specified after filename\n%s", usage);
+    goto out;
+  }
   if (arg < argc)
     filename = argv[arg];
   if (!filename) {


### PR DESCRIPTION
No double print when using invalid options.
Understand --help option.
Exits if options are put after filename.
Some more text in helper print.
