### PR TITLE
Unsigned GOPs are no longer reported

### DIFF
--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -518,22 +518,19 @@ START_TEST(all_seis_arrive_late)
   //
   // IPPIPPISPPISPPISPPISPPPSPPIPPPSP
   //
-  // IPPIPPI                        PPPPPPP                          (unsigned, 7 pending)
   // IPPIPPIS                       ...PPPP.                         (   valid, 4 pending)
   //    IPPISPPIS                      ...P.PPP.                     (   valid, 4 pending)
   //       ISPPISPPIS                     ....P.PPP.                 (   valid, 4 pending)
   //           ISPPISPPIS                     ....P.PPP.             (   valid, 4 pending)
   //               ISPPISPPPS                     ....P.PPP.         (   valid, 4 pending)
   //                   ISPPPSPPIPPPS                  ........PPPP.  (   valid, 4 pending)
-  //                                                                           31 pending
+  //                                                                           24 pending
   //                           IPPPSP                         PPPP.P (   valid, 6 pending)
   onvif_media_signing_accumulated_validation_t final_validation = {
       OMS_AUTHENTICITY_AND_PROVENANCE_OK, OMS_PROVENANCE_OK, false, OMS_AUTHENTICITY_OK,
       32, 26, 6, 0, 0};
-  const struct validation_stats expected = {.valid = 6,
-      .unsigned_gops = 1,
-      .pending_nalus = 31,
-      .final_validation = &final_validation};
+  const struct validation_stats expected = {
+      .valid = 6, .pending_nalus = 24, .final_validation = &final_validation};
   validate_test_stream(NULL, list, expected, settings[_i].ec_key);
 
   test_stream_free(list);
@@ -671,6 +668,9 @@ START_TEST(file_export_and_scrubbing)
   // ISPPPPPISPPISPPPPPPPPPISPPPPPISPISPP
   final_validation.number_of_received_nalus--;
   final_validation.number_of_validated_nalus--;
+  // The first report of stream being signed is now skipped, since it is already known.
+  expected.pending_nalus--;
+  expected.has_sei--;
   // 3) Reset and validate file again.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -682,7 +682,7 @@ START_TEST(file_export_and_scrubbing)
   final_validation.number_of_validated_nalus = 7;
   final_validation.number_of_pending_nalus = 4;
   expected.valid = 1;
-  expected.pending_nalus = 2;
+  expected.pending_nalus = 1;
   // 5) Reset and validate the first two GOPs.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, first_list, expected, settings[_i].ec_key);
@@ -695,7 +695,7 @@ START_TEST(file_export_and_scrubbing)
   final_validation.number_of_validated_nalus = 10;
   final_validation.number_of_pending_nalus = 4;
   expected.valid = 2;
-  expected.pending_nalus = 3;
+  expected.pending_nalus = 2;
   // 7) Reset and validate the rest of the file.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -1957,6 +1957,9 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   // ISPPPPSPISPPISPPPPSPPPPSPISPPPPSPISPISPP
   final_validation.number_of_received_nalus--;
   final_validation.number_of_validated_nalus--;
+  // The first report of stream being signed is now skipped, since it is already known.
+  expected.pending_nalus--;
+  expected.has_sei--;
   // 3) Validate after reset.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -1968,7 +1971,7 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   final_validation.number_of_received_nalus = 12;
   final_validation.number_of_validated_nalus = 8;
   expected.valid = 2;
-  expected.pending_nalus = 3;
+  expected.pending_nalus = 2;
   // 5) Reset and validate the first two GOPs.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, first_list, expected, settings[_i].ec_key);
@@ -1980,7 +1983,7 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   final_validation.number_of_received_nalus = 15;
   final_validation.number_of_validated_nalus = 11;
   expected.valid = 3;
-  expected.pending_nalus = 4;
+  expected.pending_nalus = 3;
   // 7) Reset and validate the rest of the file.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -2317,17 +2320,13 @@ START_TEST(unsigned_stream)
   //
   // IPPIPPIPPIPPI
   //
-  // IPPIPPI                     PPPPPP            (unsigned,  7 pending)
-  // IPPIPPIPPI                  PPPPPPPPP         (unsigned, 10 pending)
+  //                                                           0 pending
   // IPPIPPIPPIPPI               PPPPPPPPPPPP      (unsigned, 13 pending)
-  //                                                          30 pending
-  // IPPIPPIPPIPPI               PPPPPPPPPPPP      (unsigned, 13 pending)
-  // Video is not signed, hence all NAL Units are pending.
+  // Video is not signed, hence no intermediate results are provided.
   onvif_media_signing_accumulated_validation_t final_validation = {
       OMS_AUTHENTICITY_AND_PROVENANCE_NOT_FEASIBLE, OMS_PROVENANCE_NOT_FEASIBLE, false,
       OMS_NOT_SIGNED, 13, 0, 13, -1, -1};
-  const struct validation_stats expected = {
-      .unsigned_gops = 3, .pending_nalus = 30, .final_validation = &final_validation};
+  const struct validation_stats expected = {.final_validation = &final_validation};
   validate_test_stream(NULL, list, expected, settings[_i].ec_key);
 
   test_stream_free(list);
@@ -2345,17 +2344,13 @@ START_TEST(unsigned_multislice_stream)
   //
   // IiPpPpIiPpPpIiPpPpIiPpPpIi
   //
-  // IiPpPpIiPpPpI                 PPPPPPPPPPPPP               (unsigned, 13 pending)
-  // IiPpPpIiPpPpIiPpPpI           PPPPPPPPPPPPPPPPPPP         (unsigned, 19 pending)
-  // IiPpPpIiPpPpIiPpPpIiPpPpI     PPPPPPPPPPPPPPPPPPPPPPPPP   (unsigned, 25 pending)
-  //                                                                      57 pending
+  //                                                                       0 pending
   // IiPpPpIiPpPpIiPpPpIiPpPpIi    PPPPPPPPPPPPPPPPPPPPPPPPPP  (unsigned, 26 pending)
-  // Video is not signed, hence all NAL Units are pending.
+  // Video is not signed, hence no intermediate results are provided.
   onvif_media_signing_accumulated_validation_t final_validation = {
       OMS_AUTHENTICITY_AND_PROVENANCE_NOT_FEASIBLE, OMS_PROVENANCE_NOT_FEASIBLE, false,
       OMS_NOT_SIGNED, 26, 0, 26, -1, -1};
-  const struct validation_stats expected = {
-      .unsigned_gops = 3, .pending_nalus = 57, .final_validation = &final_validation};
+  const struct validation_stats expected = {.final_validation = &final_validation};
   validate_test_stream(NULL, list, expected, settings[_i].ec_key);
 
   test_stream_free(list);


### PR DESCRIPTION
Since it can only be known after processing the entire file,
reporting 'unsigned' video will not be done in intermediate
authenticity reports. The user is recommended to look in the
accumulated report for that information.

As a concequence of this change also 'stream is signed' will
only be reported once, that is, on the first infeasible SEI.
This affects scrubbing, when it is no longer reported after
a scrub. The user already knows that the video is signed.

Tests have been updated.
