### PR TITLE
Renames public API onvif_media_signing_set_max_signing_nalus

### DIFF
--- a/lib/src/includes/onvif_media_signing_signer.h
+++ b/lib/src/includes/onvif_media_signing_signer.h
@@ -75,7 +75,7 @@ extern "C" {
  *     onvif_media_signing_set_vendor_info(...)
  *     onvif_media_signing_set_emulation_prevention_before_signing(...)
  *     onvif_media_signing_set_signing_frequency(...)
- *     onvif_media_signing_set_max_signing_nalus(...)
+ *     onvif_media_signing_set_max_signing_frames(...)
  *     onvif_media_signing_set_use_certificate_sei(...)
  *     onvif_media_signing_set_low_bitrate_mode(...)
  *     onvif_media_signing_set_max_sei_payload_size(...)
@@ -380,28 +380,36 @@ onvif_media_signing_set_signing_frequency(onvif_media_signing_t *self,
     unsigned signing_frequency);
 
 /**
- * @brief Sets an upper limit on number of NAL Units before signing
+ * @brief Sets an upper limit on number of frames before signing
  *
  * The default behavior of the ONVIF Media Signing library is to sign and generate a SEI
  * every GOP (Group Of Pictures). When very long GOPs are used, the duration between
  * signatures can become impractically long, or even makes a file export on the validation
  * side infeasible to validate because the segment lacks a SEI.
  *
- * This API allows the user to set an upper limit on how many NAL Units that can be added
+ * This API allows the user to set an upper limit on how many frames that can be added
  * before sending a signing request. If this limit is reached, an intermediate SEI is
  * generated. This limit will not affect the normal behavior of signing when reaching the
  * end of a GOP (or when the signing frequency set with
  * onvif_media_signing_set_signing_frequency(...)).
- * If |max_signing_nalus| = 0, no limit is used. This is the default behavior.
+ * If |max_signing_frames| = 0, no limit is used. This is the default behavior.
  *
- * @param self              Pointer to the ONVIF Media Signing session.
- * @param max_signing_nalus Maximum number of NAL Units covered by a signatures
+ * @note the difference between 'frames' and 'NAL Units'. A frame can be split in several
+ * slices (NAL Units). To avoid creating a SEI and signing it in the middle of a frame
+ * only primary slices are counted.
+ * @note that it is the responsibility of the user to set a value that will not jeopardize
+ * the signing functionality. For example, signing every frame (max_signing_frames = 1)
+ * can be infeasible in practice since signing takes longer than the duration between
+ * frames.
+ *
+ * @param self               Pointer to the ONVIF Media Signing session.
+ * @param max_signing_frames Maximum number of frames covered by a signature.
  *
  * @returns An ONVIF Media Signing Return Code.
  */
 MediaSigningReturnCode
-onvif_media_signing_set_max_signing_nalus(onvif_media_signing_t *self,
-    unsigned max_signing_nalus);
+onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
+    unsigned max_signing_frames);
 
 /**
  * @brief Configures the ONVIF Media Signing session to use the certificate SEI concept

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -198,6 +198,8 @@ typedef struct _gop_info_t {
                             // the signing side.
   uint16_t num_nalus_in_partial_gop;  // Counted number of NAL Units in the currently
                                       // recursively updated |gop_hash|.
+  uint16_t num_frames_in_partial_gop;  // Counted number of frames in the current partial
+                                       // GOP.
   int64_t current_partial_gop;  // The index of the current partial GOP (current SEI).
   uint32_t next_partial_gop;  // The index of the next partial GOP (when decoding SEI).
   uint32_t num_partial_gop_wraparounds;  // Tracks number of times the |next_partial_gop|
@@ -235,8 +237,8 @@ struct _onvif_media_signing_t {
   size_t max_sei_payload_size;  // Default 0 = unlimited
   unsigned signing_frequency;  // Number of GOPs per signature (default 1)
   unsigned num_gops_until_signing;  // Counter to track |signing_frequency|
-  unsigned max_signing_nalus;  // Max number of NAL Units per signature (default 0, i.e.,
-                               // no limit)
+  unsigned max_signing_frames;  // Max number of NAL Units per signature (default 0, i.e.,
+                                // no limit)
 
   // Flags
   bool sei_epb;  // Flag that tells whether to generate SEI frames w/wo emulation

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -48,7 +48,7 @@ static size_t sei_size = 0;
 //   bool ep_before_signing;
 //   size_t max_sei_payload_size;
 //   bool with_certificate_sei;
-//   unsigned max_signing_nalus;
+//   unsigned max_signing_frames;
 //   unsigned signing_frequency;
 //   int delay;
 //   bool get_seis_at_end;
@@ -326,7 +326,7 @@ create_signed_splitted_nalus_int(const char *str,
   ck_assert_int_eq(omsrc, OMS_OK);
   omsrc = onvif_media_signing_set_max_sei_payload_size(oms, setting.max_sei_payload_size);
   ck_assert_int_eq(omsrc, OMS_OK);
-  omsrc = onvif_media_signing_set_max_signing_nalus(oms, setting.max_signing_nalus);
+  omsrc = onvif_media_signing_set_max_signing_frames(oms, setting.max_signing_frames);
   ck_assert_int_eq(omsrc, OMS_OK);
   omsrc = onvif_media_signing_set_signing_frequency(oms, setting.signing_frequency);
   ck_assert_int_eq(omsrc, OMS_OK);

--- a/tests/check/test_helpers.h
+++ b/tests/check/test_helpers.h
@@ -44,7 +44,7 @@ struct oms_setting {
   bool ep_before_signing;
   size_t max_sei_payload_size;
   bool with_certificate_sei;
-  unsigned max_signing_nalus;
+  unsigned max_signing_frames;
   unsigned signing_frequency;
   int delay;
   bool get_seis_at_end;


### PR DESCRIPTION
The new name is onvif_media_signing_set_max_signing_frames()
and instead of counting NAL Units, the library counts frames.
A frame can be split in several NAL Units which makes it
more difficult to configure by the user.
Also it avoids ending up hashing one NAL unit of a frame and
then signing. This would then put half of the frame in one
SEI and the other half in the next one.
