### PR TITLE
Adds a payload_offset parameter to _get_sei(...)

### DIFF
--- a/examples/apps/signer/gst-plugin/gstsigning.c
+++ b/examples/apps/signer/gst-plugin/gstsigning.c
@@ -236,7 +236,7 @@ add_seis(GstSigning *signing,
   unsigned num_pending_seis = 0;
 
   oms_rc = onvif_media_signing_get_sei(signing->priv->media_signing, &sei, &sei_size,
-      peek_nalu, peek_nalu_size, &num_pending_seis);
+      NULL, peek_nalu, peek_nalu_size, &num_pending_seis);
   while (oms_rc == OMS_OK && sei_size > 0) {
     GstMemory *prepend_mem;
 
@@ -253,7 +253,7 @@ add_seis(GstSigning *signing,
     add_count++;
 
     oms_rc = onvif_media_signing_get_sei(signing->priv->media_signing, &sei, &sei_size,
-        peek_nalu, peek_nalu_size, &num_pending_seis);
+        NULL, peek_nalu, peek_nalu_size, &num_pending_seis);
   }
 
   if (oms_rc != OMS_OK)

--- a/lib/src/includes/onvif_media_signing_signer.h
+++ b/lib/src/includes/onvif_media_signing_signer.h
@@ -135,12 +135,14 @@ extern "C" {
  *   // user can get help.
  *   uint8_t *sei = NULL;
  *   size_t sei_size = 0;
- *   status = onvif_media_signing_get_sei(oms, &sei, &sei_size, nalu, nalu_size, NULL);
+ *   status =
+ *     onvif_media_signing_get_sei(oms, &sei, &sei_size, NULL, nalu, nalu_size, NULL);
  *   while (status == OMS_OK && sei_size > 0) {
  *     status = onvif_media_signing_add_nalu_for_signing(oms, sei, sei_size, ts);
  *     // Prepend the peek NAL Unit in the current AU with this SEI. Note that the
  *     // ownership memory of the SEI has been transferred.
- *     status = onvif_media_signing_get_sei(oms, &sei, &sei_size, nalu, nalu_size, NULL);
+ *     status =
+ *       onvif_media_signing_get_sei(oms, &sei, &sei_size, NULL, nalu, nalu_size, NULL);
  *   }
  *
  *   status = onvif_media_signing_add_nalu_for_signing(oms, nalu, nalu_size, ts);
@@ -227,6 +229,10 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
  * @param sei                 A pointer to where the library adds the generated SEI.
  * @param sei_size            A pointer to where the size of the SEI will be written. If
  *   zero, no SEI is available
+ * @param payload_offset      A pointer to where the offset to the start of the SEI
+ *   payload is written. This is useful if the SEI is added by the encoder, which would
+ *   take the SEI payload only and then fill in the header, payload size and apply
+ *   emulation prevention onto the data.
  * @param peek_nalu           A pointer to the NAL Unit of which the SEI will be prepended
  *   as a header. SEIs can only be fetched if the NAL is a primary slice. Note that the
  *   |peek_nalu| must NOT been added for signing. A NULL pointer means that the user is
@@ -242,6 +248,7 @@ MediaSigningReturnCode
 onvif_media_signing_get_sei(onvif_media_signing_t *self,
     uint8_t **sei,
     size_t *sei_size,
+    unsigned *payload_offset,
     const uint8_t *peek_nalu,
     size_t peek_nalu_size,
     unsigned *num_pending_seis);

--- a/tests/check/check_onvif_media_signing_signer.c
+++ b/tests/check/check_onvif_media_signing_signer.c
@@ -227,11 +227,11 @@ START_TEST(api_inputs)
 
   uint8_t *sei = NULL;
   size_t sei_size = 0;
-  oms_rc = onvif_media_signing_get_sei(NULL, &sei, &sei_size, NULL, 0, NULL);
+  oms_rc = onvif_media_signing_get_sei(NULL, &sei, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(oms_rc, OMS_INVALID_PARAMETER);
-  oms_rc = onvif_media_signing_get_sei(oms, NULL, &sei_size, NULL, 0, NULL);
+  oms_rc = onvif_media_signing_get_sei(oms, NULL, &sei_size, NULL, NULL, 0, NULL);
   ck_assert_int_eq(oms_rc, OMS_INVALID_PARAMETER);
-  oms_rc = onvif_media_signing_get_sei(oms, &sei, NULL, NULL, 0, NULL);
+  oms_rc = onvif_media_signing_get_sei(oms, &sei, NULL, NULL, NULL, 0, NULL);
   ck_assert_int_eq(oms_rc, OMS_INVALID_PARAMETER);
 
   // Checking onvif_media_signing_set_end_of_stream() for NULL pointers.
@@ -527,7 +527,8 @@ START_TEST(display_sei_if_not_peek)
   uint8_t *sei = NULL;
   size_t sei_size = 0;
   unsigned num_pending_seis = 0;
-  omsrc = onvif_media_signing_get_sei(oms, &sei, &sei_size, NULL, 0, &num_pending_seis);
+  omsrc =
+      onvif_media_signing_get_sei(oms, &sei, &sei_size, NULL, NULL, 0, &num_pending_seis);
   ck_assert_int_eq(omsrc, OMS_OK);
   ck_assert_int_eq(num_pending_seis, 0);
   ck_assert_int_gt(sei_size, 0);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -171,7 +171,7 @@ pull_seis(onvif_media_signing_t *oms,
   // Fetch next SEI if there is none in the pipe.
   if (!sei && sei_size == 0) {
     rc = onvif_media_signing_get_sei(
-        oms, &sei, &sei_size, peek_nalu, peek_nalu_size, NULL);
+        oms, &sei, &sei_size, NULL, peek_nalu, peek_nalu_size, NULL);
     ck_assert_int_eq(rc, OMS_OK);
   }
   // To be really correct only I- & P-frames should be counted, but since this is in test
@@ -221,7 +221,7 @@ pull_seis(onvif_media_signing_t *oms,
     num_seis++;
     // Ask for next completed SEI.
     rc = onvif_media_signing_get_sei(
-        oms, &sei, &sei_size, peek_nalu, peek_nalu_size, NULL);
+        oms, &sei, &sei_size, NULL, peek_nalu, peek_nalu_size, NULL);
     ck_assert_int_eq(rc, OMS_OK);
   }
   int pulled_seis = num_seis;


### PR DESCRIPTION
Now the user is able to get the number of bytes into the SEI that
the actual SEI payload starts.
