### PR TITLE
Renames meson parameters

### DIFF
--- a/examples/apps/signer/gst-plugin/gst-signing-plugin.c
+++ b/examples/apps/signer/gst-plugin/gst-signing-plugin.c
@@ -47,5 +47,5 @@ GST_PLUGIN_DEFINE(GST_VERSION_MAJOR,
     plugin_init,
     VERSION,
     GST_LICENSE_UNKNOWN,
-    "SignedMediaFramework",
+    "MediaSigningFramework",
     "www.github.com/onvif/media-signing-framework")

--- a/examples/apps/signer/gst-plugin/meson.build
+++ b/examples/apps/signer/gst-plugin/meson.build
@@ -28,6 +28,6 @@ gstsigning = shared_library('gstsigning',
   build_rpath : oms_lib_dir,
   install_rpath : oms_lib_dir,
   dependencies : [ gst_dep, gstbase_dep ],
-  link_with : signedmediaframework,
+  link_with : mediasigningframework,
   install : true,
 )

--- a/examples/apps/validator/meson.build
+++ b/examples/apps/validator/meson.build
@@ -13,6 +13,6 @@ executable('validator',
   build_rpath : oms_lib_dir,
   install_rpath : oms_lib_dir,
   dependencies : [ gst_dep, gstapp_dep ],
-  link_with : signedmediaframework,
+  link_with : mediasigningframework,
   install : true,
 )

--- a/lib/src/meson.build
+++ b/lib/src/meson.build
@@ -1,4 +1,4 @@
-signedmediaframework_public_headers = files(
+mediasigningframework_public_headers = files(
   'includes/onvif_media_signing_common.h',
   'includes/onvif_media_signing_helpers.h',
   'includes/onvif_media_signing_plugin.h',
@@ -6,7 +6,7 @@ signedmediaframework_public_headers = files(
   'includes/onvif_media_signing_validator.h',
 )
 
-signedmediaframework_sources = files(
+mediasigningframework_sources = files(
   'oms_authenticity_report.c',
   'oms_authenticity_report.h',
   'oms_common.c',
@@ -24,27 +24,27 @@ signedmediaframework_sources = files(
 )
 
 # Until plugin management is in place the plugin file(s) are added to the sources.
-signedmediaframework_sources += plugin_sources
+mediasigningframework_sources += plugin_sources
 
 openssl_dep = dependency('openssl', required : true, version : '>=3.0.0')
 
 install_headers(
-    signedmediaframework_public_headers,
+    mediasigningframework_public_headers,
     install_dir : '@0@/media-signing-framework'.format(get_option('includedir')))
 
-signedmediaframework_deps = [ openssl_dep, plugin_deps ]
+mediasigningframework_deps = [ openssl_dep, plugin_deps ]
 
-signedmediaframework = shared_library(
+mediasigningframework = shared_library(
     'media-signing-framework',
-    signedmediaframework_sources,
+    mediasigningframework_sources,
     version : meson.project_version(),
-    dependencies : signedmediaframework_deps,
+    dependencies : mediasigningframework_deps,
     install : true,
 )
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(
-    signedmediaframework,
+    mediasigningframework,
     name : 'media-signing-framework',
     description : 'ONVIF Media Signing Framework',
 )

--- a/tests/check/meson.build
+++ b/tests/check/meson.build
@@ -50,7 +50,7 @@ foreach t : tests
                        t[1],
                        include_directories : [ configinc, testinc ],
                        dependencies : [ check_dep ],
-                       link_with : signedmediaframework)
+                       link_with : mediasigningframework)
   # run tests in own directories
   workdir = join_paths(meson.current_build_dir(), t[0] + '@workdir')
   run_command('sh', '-c', 'mkdir -p ' + workdir, check : true)


### PR DESCRIPTION
Previous names were 'signedmedia*', which now has changed to
'mediasigning*'
