### PR TITLE
Changes behavior when comparing versions

### DIFF
--- a/lib/src/includes/onvif_media_signing_common.h
+++ b/lib/src/includes/onvif_media_signing_common.h
@@ -142,6 +142,10 @@ onvif_media_signing_get_version();
  * done with a newer version of this library than what is used in the validation firmware
  * there is no guarantee that validation can be performed correctly.
  *
+ * The comparison is done on major and minor numbers only. Patch number should not affect
+ * changes in the validation result. This makes it more convenient to keep, for example,
+ * a media player up to date.
+ *
  * @param version1 First version string for comparison
  * @param version2 Second version string for comparison
  *

--- a/lib/src/oms_authenticity_report.c
+++ b/lib/src/oms_authenticity_report.c
@@ -233,6 +233,7 @@ authenticity_report_init(onvif_media_signing_authenticity_t *authenticity_report
   assert(!authenticity_report->this_version);
   authenticity_report->version_on_signing_side = calloc(1, OMS_VERSION_MAX_STRLEN);
   authenticity_report->this_version = calloc(1, OMS_VERSION_MAX_STRLEN);
+  strcpy(authenticity_report->this_version, ONVIF_MEDIA_SIGNING_VERSION);
 
   latest_validation_init(&authenticity_report->latest_validation);
   accumulated_validation_init(&authenticity_report->accumulated_validation);

--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -1139,7 +1139,7 @@ onvif_media_signing_compare_versions(const char *version1, const char *version2)
 
   int result = 0;
   int j = 0;
-  while (result == 0 && j < OMS_VERSION_BYTES) {
+  while (result == 0 && j < OMS_VERSION_BYTES - 1) {
     result = arr1[j] - arr2[j];
     j++;
   }


### PR DESCRIPTION
There is a check for version mismatch between signing and
validation. If the stream has been signed with a newer version
than what is used when validating the validation result cannot
be guaranteed. The reason is that it is not possible to be
forward compatible.
However, if the change is minor, like when the patch number
only has changed, it should still be possible to trust the
result.

This commit checks only major and minor for version mismatch.

Also, the authenticity report is now initialized with the current
version.
