### PR TITLE
Latest validation always displays the timestamp of first NAL Unit

### DIFF
--- a/lib/src/oms_defines.h
+++ b/lib/src/oms_defines.h
@@ -42,7 +42,7 @@ typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Re
 #endif
 
 #define OMS_VERSION_BYTES 3
-#define ONVIF_MEDIA_SIGNING_VERSION "v1.0.0"
+#define ONVIF_MEDIA_SIGNING_VERSION "v1.0.1"
 #define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
 
 // Maximum number of ongoing and completed SEIs to hold until the user fetches them

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -211,7 +211,11 @@ typedef struct _gop_info_t {
                                       // segment is detected.
   int verified_signature;  // Status of last hash-signature-pair verification. Has 1 for
                            // success, 0 for fail, and -1 for error.
-  int64_t timestamp;  // Unix epoch UTC timestamp of the first nalu in GOP
+  // UTC based time represented by the number of 100-nanosecond intervals since January 1,
+  // 1601.
+  int64_t start_timestamp;  // Timestamp of first NAL Unit in (partial) GOP.
+  int64_t end_timestamp;  // End timestamp (exclusive) of (partial) GOP. Partial GOP
+                          // duration is |end_timestamp| - |start_timestamp|.
 } gop_info_t;
 
 struct _onvif_media_signing_t {

--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -559,8 +559,9 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
       // An I-frame indicates the start of a new GOP, hence trigger generating a SEI. This
       // also means that the signing feature is present.
 
-      // Store the timestamp for the first NAL Unit in gop.
-      gop_info->timestamp = timestamp;
+      // Update the timestamp for the partial GOP.
+      gop_info->start_timestamp = gop_info->end_timestamp;
+      gop_info->end_timestamp = timestamp;
       // Generate a GOP hash
       gop_info->num_nalus_in_partial_gop = hashed_nalus;
       if (gop_info->hash_list_idx == 0) {

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('media-signing-framework', 'c',
-  version : '1.0.0',
+  version : '1.0.1',
   meson_version : '>= 0.49.0',
   default_options : [ 'warning_level=2',
                       'werror=true',

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -262,6 +262,12 @@ create_signed_nalus_with_oms(onvif_media_signing_t *oms,
     if (!get_seis_at_end || (get_seis_at_end && item->next == NULL)) {
       pulled_seis = pull_seis(oms, &item, apply_ep, delay);
     }
+    if (item->type == 'I' || item->type == 'P') {
+      // Increment timestamp when there is a new primary slice. This is not truly correct,
+      // for example, a (prepended) SEI will now get a different timestamp as the slice.
+      // For tests though, it serves its purpose.
+      timestamp += 400000;  // One frame if 25 fps.
+    }
     if (split_nalus && pulled_seis == 0) {
       // Split the NAL Unit into 2 parts, where the last part inlcudes the ID and the stop
       // bit.
@@ -275,7 +281,6 @@ create_signed_nalus_with_oms(onvif_media_signing_t *oms,
           oms, item->data, item->data_size, timestamp, true);
     }
     ck_assert_int_eq(rc, OMS_OK);
-    timestamp += 400000;  // One frame if 25 fps.
 
     if (item->next == NULL) {
       if (sei) {

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -257,16 +257,15 @@ create_signed_nalus_with_oms(onvif_media_signing_t *oms,
 
   // Loop through the NAL Units and add for signing.
   while (item) {
+    if (item->type == 'I' || item->type == 'P') {
+      // Increment timestamp when there is a new primary slice. Prepended SEIs will get
+      // the same timestamp as the slice.
+      timestamp += 400000;  // One frame if 25 fps.
+    }
     // Pull all SEIs and add them into the test stream.
     int pulled_seis = 0;
     if (!get_seis_at_end || (get_seis_at_end && item->next == NULL)) {
       pulled_seis = pull_seis(oms, &item, apply_ep, delay);
-    }
-    if (item->type == 'I' || item->type == 'P') {
-      // Increment timestamp when there is a new primary slice. This is not truly correct,
-      // for example, a (prepended) SEI will now get a different timestamp as the slice.
-      // For tests though, it serves its purpose.
-      timestamp += 400000;  // One frame if 25 fps.
     }
     if (split_nalus && pulled_seis == 0) {
       // Split the NAL Unit into 2 parts, where the last part inlcudes the ID and the stop


### PR DESCRIPTION
No matter how many GOPs are included in one signature, the latest
authenticity report should display the timestamp of the first NAL
Unit.

In addition to the fix above, the tests only increment the
timestamp upon primary slices.
