### PR TITLE
Moves update_hashable_data into nalu parser

### DIFF
--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -336,10 +336,4 @@ void
 oms_print_hex_data(const uint8_t *data, size_t data_size, const char *fmt, ...);
 #endif
 
-/* Definitions in oms_validator.c. */
-#ifdef ONVIF_MEDIA_SIGNING_DEBUG
-void
-update_hashable_data(nalu_info_t *nalu_info);
-#endif
-
 #endif  // __OMS_INTERNAL_H__

--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -155,7 +155,6 @@ complete_sei(onvif_media_signing_t *self)
     uint8_t test_hash[MAX_HASH_SIZE];
     nalu_info_t test_nalu_info =
         parse_nalu_info(sei, sei_data->completed_sei_size, self->codec, false, true);
-    update_hashable_data(&test_nalu_info);
     OMS_THROW(simply_hash(self, &test_nalu_info, test_hash, self->sign_data->hash_size));
     free(test_nalu_info.nalu_wo_epb);
     // Borrow hash and signature from |sign_data|.


### PR DESCRIPTION
When parsing the NAL Unit information also getting the correct
size of hashable_data is now done. This makes the function
update_hashable_data() obsolete and has been removed.
