### PR TITLE
Adds an in_validation member to nalu_list_item_t

### DIFF
--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -116,6 +116,9 @@ struct _nalu_list_item_t {
   // vital information.
   int verified_signature;
 
+  // Members used when synchronizing the first usable SEI with the I-frame(s).
+  bool in_validation;  // Marks the SEI that is currently up for use.
+
   // Linked list
   nalu_list_item_t *prev;  // Points to the previously added NAL Unit. Is NULL if this is
   // the first item.

--- a/lib/src/oms_nalu_list.c
+++ b/lib/src/oms_nalu_list.c
@@ -502,8 +502,15 @@ nalu_list_get_stats(const nalu_list_t *list,
     if (item->validation_status == 'M') {
       local_num_missing_nalus++;
     }
-    if (item->validation_status == 'N' || item->validation_status == 'E') {
-      local_num_invalid_nalus++;
+    if (item->nalu_info && item->nalu_info->is_oms_sei) {
+      if (item->in_validation &&
+          (item->validation_status == 'N' || item->validation_status == 'E')) {
+        local_num_invalid_nalus++;
+      }
+    } else {
+      if (item->validation_status == 'N' || item->validation_status == 'E') {
+        local_num_invalid_nalus++;
+      }
     }
     if (item->validation_status == '.') {
       // Do not count SEIs, since they are marked valid if the signature could be

--- a/lib/src/oms_validator.c
+++ b/lib/src/oms_validator.c
@@ -809,6 +809,7 @@ prepare_for_validation(onvif_media_signing_t *self, nalu_list_item_t **sei)
 
   oms_rc status = OMS_UNKNOWN_FAILURE;
   OMS_TRY()
+    (*sei)->in_validation = true;
     if (!(*sei)->has_been_decoded) {
       // Decode the SEI and set signature->hash
       const uint8_t *tlv_data = (*sei)->nalu_info->tlv_data;


### PR DESCRIPTION
This will be used to handle SEIs in the beginning of a session
before the first synchronization has been made.
