### PR TITLE
Adds a new member tmp_validation_status to nalu_list_item_t

### DIFF
--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -118,6 +118,7 @@ struct _nalu_list_item_t {
 
   // Members used when synchronizing the first usable SEI with the I-frame(s).
   bool in_validation;  // Marks the SEI that is currently up for use.
+  char tmp_validation_status;  // Temporary status used before updating the final one.
 
   // Linked list
   nalu_list_item_t *prev;  // Points to the previously added NAL Unit. Is NULL if this is

--- a/lib/src/oms_nalu_list.h
+++ b/lib/src/oms_nalu_list.h
@@ -156,6 +156,18 @@ nalu_list_item_t*
 nalu_list_get_next_sei_item(const nalu_list_t* list);
 
 /**
+ * @brief Updates or resets validation status of all items in a list
+ *
+ * @param list The |list| to count pending items.
+ * @param update Updates |validation_status| with |tmp_validation_status| if 'true',
+ *   otherwise resets |tmp_validation_status| with |validation_status|.
+ *
+ * @return An appropriate ONVIF Media Signing Return Code.
+ */
+oms_rc
+nalu_list_update_status(nalu_list_t* list, bool update);
+
+/**
  * @brief Collects statistics from a list
  *
  * Loops through the |list| and collects statistics.


### PR DESCRIPTION
To be able to revert a validation result, the validation process
is performed on a temporary variable tmp_validation_status.
After validation has been completed the tmp_validation_status
is transformed to validation_status.
