### PR TITLE
Adds update_sei_in_validation

### DIFF
--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -650,11 +650,16 @@ START_TEST(file_export_and_scrubbing)
   //                                                                          6 pending
   //                                  ISPP                   P.PP    ( valid, 4 pending)
   onvif_media_signing_accumulated_validation_t final_validation = {
-      OMS_AUTHENTICITY_AND_PROVENANCE_OK, OMS_PROVENANCE_OK, false, OMS_AUTHENTICITY_OK,
+      OMS_AUTHENTICITY_AND_PROVENANCE_NOT_OK,  // OMS_AUTHENTICITY_AND_PROVENANCE_OK,
+      OMS_PROVENANCE_OK, false,
+      OMS_AUTHENTICITY_NOT_OK,  // OMS_AUTHENTICITY_OK,
       37, 33, 4, 0, 0};
-  struct validation_stats expected = {.valid = 5,
-      .has_sei = 1,
-      .pending_nalus = 6,
+  struct validation_stats expected = {.valid = 3,  // 5,
+      .valid_with_missing_info = 1,  // 0,
+      .invalid = 2,  // 0,
+      .missed_nalus = 1,  // 0,
+      .has_sei = 0,  // 1,
+      .pending_nalus = 5,  // 6,
       .final_validation = &final_validation};
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
 
@@ -665,8 +670,12 @@ START_TEST(file_export_and_scrubbing)
   final_validation.number_of_received_nalus--;
   final_validation.number_of_validated_nalus--;
   // The first report of stream being signed is now skipped, since it is already known.
-  expected.pending_nalus--;
-  expected.has_sei--;
+  // expected.pending_nalus--;
+  // expected.has_sei--;
+  // Temporary changes
+  expected.valid_with_missing_info = 0;
+  expected.invalid++;
+  expected.missed_nalus = 3;
   // 3) Reset and validate file again.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -677,8 +686,10 @@ START_TEST(file_export_and_scrubbing)
   final_validation.number_of_received_nalus = 11;
   final_validation.number_of_validated_nalus = 7;
   final_validation.number_of_pending_nalus = 4;
-  expected.valid = 1;
+  expected.valid = 0;  // 1;
   expected.pending_nalus = 1;
+  // Temporary changes
+  expected.invalid--;
   // 5) Reset and validate the first two GOPs.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, first_list, expected, settings[_i].ec_key);
@@ -690,8 +701,11 @@ START_TEST(file_export_and_scrubbing)
   final_validation.number_of_received_nalus = 14;
   final_validation.number_of_validated_nalus = 10;
   final_validation.number_of_pending_nalus = 4;
-  expected.valid = 2;
+  expected.valid = 0;  // 2;
   expected.pending_nalus = 2;
+  // Temporary changes
+  expected.invalid++;
+  expected.missed_nalus = 10;
   // 7) Reset and validate the rest of the file.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -858,9 +872,10 @@ START_TEST(modify_one_p_frame)
   onvif_media_signing_accumulated_validation_t final_validation = {
       OMS_AUTHENTICITY_AND_PROVENANCE_NOT_OK, OMS_PROVENANCE_OK, false,
       OMS_AUTHENTICITY_NOT_OK, 15, 12, 3, 0, 0};
-  const struct validation_stats expected = {.valid = 2,
-      .invalid = 1,
-      .pending_nalus = 3,
+  const struct validation_stats expected = {.valid = 0,  // 2,
+      .invalid = 3,  // 1,
+      .missed_nalus = 3,  // 0,
+      .pending_nalus = 2,  // 3,
       .final_validation = &final_validation};
   validate_test_stream(NULL, list, expected, settings[_i].ec_key);
 
@@ -1473,10 +1488,11 @@ START_TEST(file_export_with_two_useless_seis)
       OMS_AUTHENTICITY_AND_PROVENANCE_NOT_OK, OMS_PROVENANCE_OK, false,
       OMS_AUTHENTICITY_NOT_OK, 17, 14, 3, 0, 0};
   const struct validation_stats expected = {.valid = 0,
+      .valid_with_missing_info = 1,  // 0,
       .invalid = 4,
-      .missed_nalus = 4,
-      .pending_nalus = 8,
-      .has_sei = 1,
+      .missed_nalus = 7,  // 4,
+      .pending_nalus = 5,  // 8,
+      .has_sei = 0,  // 1,
       .final_validation = &final_validation};
 
   validate_test_stream(NULL, list, expected, true);
@@ -2054,11 +2070,16 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   //                                                                          10 pending
   //                                      ISPP                   P.PP ( valid, 4 pending)
   onvif_media_signing_accumulated_validation_t final_validation = {
-      OMS_AUTHENTICITY_AND_PROVENANCE_OK, OMS_PROVENANCE_OK, false, OMS_AUTHENTICITY_OK,
+      OMS_AUTHENTICITY_AND_PROVENANCE_NOT_OK,  // OMS_AUTHENTICITY_AND_PROVENANCE_OK,
+      OMS_PROVENANCE_OK, false,
+      OMS_AUTHENTICITY_NOT_OK,  // OMS_AUTHENTICITY_OK,
       41, 37, 4, 0, 0};
-  struct validation_stats expected = {.valid = 9,
-      .has_sei = 1,
-      .pending_nalus = 10,
+  struct validation_stats expected = {.valid = 6,  // 9,
+      .valid_with_missing_info = 1,  // 0,
+      .invalid = 3,  // 0,
+      .missed_nalus = 1,  // 0,
+      .has_sei = 0,  // 1,
+      .pending_nalus = 8,  // 10,
       .final_validation = &final_validation};
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
 
@@ -2069,8 +2090,12 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   final_validation.number_of_received_nalus--;
   final_validation.number_of_validated_nalus--;
   // The first report of stream being signed is now skipped, since it is already known.
-  expected.pending_nalus--;
-  expected.has_sei--;
+  // expected.pending_nalus--;
+  // expected.has_sei--;
+  // Temporary changes
+  expected.valid_with_missing_info--;
+  expected.invalid++;
+  expected.missed_nalus = 3;
   // 3) Validate after reset.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);
@@ -2081,8 +2106,10 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   // No report triggered.
   final_validation.number_of_received_nalus = 12;
   final_validation.number_of_validated_nalus = 8;
-  expected.valid = 2;
-  expected.pending_nalus = 2;
+  expected.valid = 0;  // 2;
+  expected.pending_nalus = 1;  // 2;
+  // Temporary changes
+  expected.invalid--;
   // 5) Reset and validate the first two GOPs.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, first_list, expected, settings[_i].ec_key);
@@ -2093,8 +2120,11 @@ START_TEST(file_export_and_scrubbing_partial_gops)
   // ISPPPPSPISPISPP
   final_validation.number_of_received_nalus = 15;
   final_validation.number_of_validated_nalus = 11;
-  expected.valid = 3;
-  expected.pending_nalus = 3;
+  expected.valid = 0;  // 3;
+  expected.pending_nalus = 2;  // 3;
+  // Temporary changes
+  expected.invalid++;
+  expected.missed_nalus = 2;
   // 7) Reset and validate the rest of the file.
   ck_assert_int_eq(onvif_media_signing_reset(oms), OMS_OK);
   validate_test_stream(oms, list, expected, settings[_i].ec_key);


### PR DESCRIPTION
At the beginning of a session when SEIs are not in sync they
will be used in attempts for validation. Therefore, a SEI that
is in_validation needs to get its validation_status reset
between these attempts.

A general function that applies operations on the SEI
in_validation is added and called in some places.

This commit affects four tests. These tests have been changed
temporarily until the full implementation has been completed.
