### PR TITLE
Separates SEI synchronization

### DIFF
--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -199,7 +199,7 @@ gop_info_create(void)
     return NULL;
   }
 
-  gop_info->current_partial_gop = 0;
+  gop_info->current_partial_gop = -1;
   // Initialize |verified_signature| as 'error'.
   gop_info->verified_signature = -1;
 
@@ -225,7 +225,7 @@ gop_info_reset(gop_info_t *gop_info)
   gop_info->hash_list_idx = 0;
   gop_info->has_anchor_hash = false;
   gop_info->global_gop_counter_is_synced = false;
-  gop_info->current_partial_gop = 0;
+  gop_info->current_partial_gop = -1;
   gop_info->next_partial_gop = 0;
   gop_info->num_partial_gop_wraparounds = 0;
   memset(gop_info->linked_hash, 0, MAX_HASH_SIZE * 2);

--- a/lib/src/oms_defines.h
+++ b/lib/src/oms_defines.h
@@ -42,7 +42,7 @@ typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Re
 #endif
 
 #define OMS_VERSION_BYTES 3
-#define ONVIF_MEDIA_SIGNING_VERSION "v1.0.1"
+#define ONVIF_MEDIA_SIGNING_VERSION "v1.0.2"
 #define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
 
 // Maximum number of ongoing and completed SEIs to hold until the user fetches them

--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -585,6 +585,9 @@ onvif_media_signing_add_nalu_part_for_signing(onvif_media_signing_t *self,
         }
       }
       // Increment GOP counter since a new (partial) GOP is detected.
+      if (gop_info->current_partial_gop < 0) {
+        gop_info->current_partial_gop = 0;
+      }
       gop_info->current_partial_gop++;
       if (new_gop) {
         self->num_gops_until_signing--;

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('media-signing-framework', 'c',
-  version : '1.0.1',
+  version : '1.0.2',
   meson_version : '>= 0.49.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
SEI synchronization is separated from the rest of the validation.
Special actions if |is_first_validation| is now done based on
whether SEIs are in sync or not.

This commit also includes
* Init of current_partial_gop to -1 instead of 0
* New input parameter to verify_linked_hash()
* Restructure of has_pending_partial_gop()

Tests have been updated accordingly.

Bumps version to v1.0.2
