### PR TITLE
Handles arbitrary data according to specification

### DIFF
--- a/lib/src/oms_defines.h
+++ b/lib/src/oms_defines.h
@@ -42,7 +42,7 @@ typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Re
 #endif
 
 #define OMS_VERSION_BYTES 3
-#define ONVIF_MEDIA_SIGNING_VERSION "r25.12.1"
+#define ONVIF_MEDIA_SIGNING_VERSION "r25.12.2"
 #define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
 
 // Maximum number of ongoing and completed SEIs to hold until the user fetches them

--- a/lib/src/oms_internal.h
+++ b/lib/src/oms_internal.h
@@ -238,6 +238,8 @@ struct _onvif_media_signing_t {
                             // automatically
   // sent through the ARBITRARY_DATA_TAG.
   size_t arbitrary_data_size;  // Size of |arbitrary_data|.
+  bool arbitrary_data_not_alone;  // Flags if the Arbitrary data tag is present together
+  // with other tags in the same SEI.
 
   // Members only used for signing
 

--- a/lib/src/oms_tlv.c
+++ b/lib/src/oms_tlv.c
@@ -144,7 +144,6 @@ static const oms_tlv_tag_t optional_tags[] = {
 static const oms_tlv_tag_t mandatory_tags[] = {
     GENERAL_TAG,
     HASH_LIST_TAG,
-    ARBITRARY_DATA_TAG,
 };
 
 /**
@@ -243,7 +242,7 @@ encode_general(onvif_media_signing_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts >> 24) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts >> 16) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts)&0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts) & 0x000000ff), epb);
   // Write end timestamp; 8 bytes
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 56) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 48) & 0x000000ff), epb);
@@ -252,17 +251,17 @@ encode_general(onvif_media_signing_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 24) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 16) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts)&0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts) & 0x000000ff), epb);
   // GOP counter; 4 bytes
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 24) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 16) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter)&0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter) & 0x000000ff), epb);
   // Write num_nalus_in_partial_gop; 2 bytes
   write_byte(last_two_bytes, &data_ptr,
       (uint8_t)((num_nalus_in_partial_gop >> 8) & 0x00ff), epb);
   write_byte(
-      last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_partial_gop)&0x00ff), epb);
+      last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_partial_gop) & 0x00ff), epb);
   // Write the partial_gop_hash; hash_size bytes
   write_byte_many(&data_ptr, gop_info->partial_gop_hash, hash_size, last_two_bytes, epb);
   // Write the linked_hash; hash_size bytes
@@ -465,7 +464,7 @@ encode_signature(onvif_media_signing_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write actual signature size (2 bytes)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size >> 8) & 0x00ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size)&0x00ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size) & 0x00ff), epb);
   // Write signature
   size_t i = 0;
   for (; i < signature_size; i++) {
@@ -595,7 +594,7 @@ encode_crypto_info(onvif_media_signing_t *self, uint8_t *data)
   }
   // RSA encryption size (2 bytes)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((rsa_size >> 8) & 0x00ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((rsa_size)&0x00ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((rsa_size) & 0x00ff), epb);
 
   return (data_ptr - data);
 }
@@ -1096,6 +1095,8 @@ tlv_decode(onvif_media_signing_t *self, const uint8_t *data, size_t data_size)
     return OMS_INVALID_PARAMETER;
   }
 
+  bool has_arbitrary_data_tag = false;
+  bool has_other_tag = false;
   while (data_ptr < data + data_size) {
     oms_tlv_tag_t tag = 0;
     size_t tlv_header_size = 0;
@@ -1105,6 +1106,8 @@ tlv_decode(onvif_media_signing_t *self, const uint8_t *data, size_t data_size)
       DEBUG_LOG("Could not decode TLV header (error %d)", status);
       break;
     }
+    has_arbitrary_data_tag |= tag == ARBITRARY_DATA_TAG;
+    has_other_tag |= tag != ARBITRARY_DATA_TAG;
     data_ptr += tlv_header_size;
 
     oms_tlv_decoder_t decoder = get_decoder(tag);
@@ -1114,6 +1117,9 @@ tlv_decode(onvif_media_signing_t *self, const uint8_t *data, size_t data_size)
       break;
     }
     data_ptr += length;
+  }
+  if (has_arbitrary_data_tag && has_other_tag) {
+    self->arbitrary_data_not_alone |= true;
   }
 
   return status;
@@ -1180,6 +1186,8 @@ tlv_find_and_decode_tags(onvif_media_signing_t *self,
 
   oms_rc status = OMS_UNKNOWN_FAILURE;
   int decoded_tags = 0;
+  bool has_arbitrary_data_tag = false;
+  bool has_other_tag = false;
   while (tlv_data_ptr < tlv_data + tlv_data_size) {
     size_t tlv_header_size = 0;
     size_t length = 0;
@@ -1189,6 +1197,8 @@ tlv_find_and_decode_tags(onvif_media_signing_t *self,
       DEBUG_LOG("Could not decode tlv header");
       break;
     }
+    has_arbitrary_data_tag |= this_tag == ARBITRARY_DATA_TAG;
+    has_other_tag |= this_tag != ARBITRARY_DATA_TAG;
     tlv_data_ptr += tlv_header_size;
     if (tag_is_present(this_tag, tags, num_of_tags)) {
       oms_tlv_decoder_t decoder = get_decoder(this_tag);
@@ -1200,6 +1210,9 @@ tlv_find_and_decode_tags(onvif_media_signing_t *self,
       decoded_tags++;
     }
     tlv_data_ptr += length;
+  }
+  if (has_arbitrary_data_tag && has_other_tag) {
+    self->arbitrary_data_not_alone |= true;
   }
 
   return decoded_tags > 0;

--- a/lib/src/oms_validator.c
+++ b/lib/src/oms_validator.c
@@ -535,6 +535,10 @@ validate_authenticity(onvif_media_signing_t *self, nalu_list_item_t *sei)
   if (latest->public_key_has_changed) {
     valid = OMS_AUTHENTICITY_NOT_OK;
   }
+  if (self->arbitrary_data_not_alone) {
+    // Specification requires arbitrary data to be put in a separate SEI.
+    valid = OMS_AUTHENTICITY_NOT_OK;
+  }
 
   // Update |latest_validation| with the validation result.
   if (latest->authenticity <= OMS_AUTHENTICITY_NOT_FEASIBLE) {

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('media-signing-framework', 'c',
-  version : '25.12.1',
+  version : '25.12.2',
   meson_version : '>= 0.49.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
Flags validation as not authentic if arbitrary data is present
together with other tags. Also removes tag from mandatory_tags
since it by definition shall be treated separately.

Bumps version to r25.12.2.
