### PR TITLE
Fixes a vulnerability in decode_general

### DIFF
--- a/lib/src/oms_defines.h
+++ b/lib/src/oms_defines.h
@@ -42,7 +42,7 @@ typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Re
 #endif
 
 #define OMS_VERSION_BYTES 3
-#define ONVIF_MEDIA_SIGNING_VERSION "r25.12.1"
+#define ONVIF_MEDIA_SIGNING_VERSION "r25.12.2"
 #define OMS_VERSION_MAX_STRLEN 13  // Longest possible string
 
 // Maximum number of ongoing and completed SEIs to hold until the user fetches them
@@ -148,8 +148,7 @@ typedef MediaSigningReturnCode oms_rc;  // Short Name for ONVIF Media Signing Re
   oms_rc status_; \
   bool status_set_ = false;
 #define OMS_CATCH() \
-  catch_error: \
-  if (!status_set_) { \
+  catch_error : if (!status_set_) { \
     DEBUG_LOG("status_ was never set, which means no THROW call was used"); \
     status_ = OMS_OK; \
   } \

--- a/lib/src/oms_tlv.c
+++ b/lib/src/oms_tlv.c
@@ -243,7 +243,7 @@ encode_general(onvif_media_signing_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts >> 24) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts >> 16) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts)&0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((start_ts) & 0x000000ff), epb);
   // Write end timestamp; 8 bytes
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 56) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 48) & 0x000000ff), epb);
@@ -252,17 +252,17 @@ encode_general(onvif_media_signing_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 24) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 16) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts)&0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((end_ts) & 0x000000ff), epb);
   // GOP counter; 4 bytes
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 24) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 16) & 0x000000ff), epb);
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter >> 8) & 0x000000ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter)&0x000000ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((gop_counter) & 0x000000ff), epb);
   // Write num_nalus_in_partial_gop; 2 bytes
   write_byte(last_two_bytes, &data_ptr,
       (uint8_t)((num_nalus_in_partial_gop >> 8) & 0x00ff), epb);
   write_byte(
-      last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_partial_gop)&0x00ff), epb);
+      last_two_bytes, &data_ptr, (uint8_t)((num_nalus_in_partial_gop) & 0x00ff), epb);
   // Write the partial_gop_hash; hash_size bytes
   write_byte_many(&data_ptr, gop_info->partial_gop_hash, hash_size, last_two_bytes, epb);
   // Write the linked_hash; hash_size bytes
@@ -328,6 +328,7 @@ decode_general(onvif_media_signing_t *self, const uint8_t *data, size_t data_siz
     DEBUG_LOG("Number of sent NAL Units = %u", gop_info->num_sent_nalus);
     // Read (partial) GOP hash. Remaining data is split into two hashes of equal size.
     size_t hash_size = (data_size - (data_ptr - data)) / 2;
+    OMS_THROW_IF(hash_size > MAX_HASH_SIZE, OMS_AUTHENTICATION_ERROR);
     uint16_t last_two_bytes = 0xffff;  // Not needed
     read_byte_many(
         gop_info->partial_gop_hash, &data_ptr, hash_size, &last_two_bytes, false);
@@ -465,7 +466,7 @@ encode_signature(onvif_media_signing_t *self, uint8_t *data)
   write_byte(last_two_bytes, &data_ptr, version, epb);
   // Write actual signature size (2 bytes)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size >> 8) & 0x00ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size)&0x00ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((signature_size) & 0x00ff), epb);
   // Write signature
   size_t i = 0;
   for (; i < signature_size; i++) {
@@ -595,7 +596,7 @@ encode_crypto_info(onvif_media_signing_t *self, uint8_t *data)
   }
   // RSA encryption size (2 bytes)
   write_byte(last_two_bytes, &data_ptr, (uint8_t)((rsa_size >> 8) & 0x00ff), epb);
-  write_byte(last_two_bytes, &data_ptr, (uint8_t)((rsa_size)&0x00ff), epb);
+  write_byte(last_two_bytes, &data_ptr, (uint8_t)((rsa_size) & 0x00ff), epb);
 
   return (data_ptr - data);
 }

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('media-signing-framework', 'c',
-  version : '25.12.1',
+  version : '25.12.2',
   meson_version : '>= 0.49.0',
   default_options : [ 'warning_level=2',
                       'werror=true',


### PR DESCRIPTION
An attacker can (probably) create a SEI with a too large general
TLV tag and write outside hash members ending up inside
authenticity result data. This could then alter the validation
result to VALID when it is not.
