### PR TITLE
Supports generating certificate SEIs during session

### DIFF
--- a/examples/apps/signer/gst-plugin/gstsigning.c
+++ b/examples/apps/signer/gst-plugin/gstsigning.c
@@ -39,9 +39,12 @@
 GST_DEBUG_CATEGORY_STATIC(gst_signing_debug);
 #define GST_CAT_DEFAULT gst_signing_debug
 
+static guint frame_count = 0;
+
 enum {
   PROP_0,
-  PROP_BASETIME
+  PROP_BASETIME,
+  PROP_CERT_SEI
 };
 
 struct _GstSigningPrivate {
@@ -49,6 +52,7 @@ struct _GstSigningPrivate {
   MediaSigningCodec codec;
   GstClockTime last_pts;
   GstClockTime basetime;
+  int cert_sei_interval;
 };
 
 #define TEMPLATE_CAPS \
@@ -91,6 +95,9 @@ gst_signing_get_property(GObject *object, guint prop_id, GValue *value, GParamSp
     case PROP_BASETIME:
       g_value_set_uint64(value, signing->priv->basetime);
       break;
+    case PROP_CERT_SEI:
+      g_value_set_int(value, signing->priv->cert_sei_interval);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
       break;
@@ -112,6 +119,11 @@ gst_signing_set_property(GObject *object,
     case PROP_BASETIME:
       priv->basetime = g_value_get_uint64(value);
       GST_DEBUG_OBJECT(object, "new basetime: %lu", priv->basetime);
+      break;
+    case PROP_CERT_SEI:
+      priv->cert_sei_interval = g_value_get_int(value);
+      GST_DEBUG_OBJECT(
+          object, "new certificate sei interval: %d", priv->cert_sei_interval);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -149,6 +161,10 @@ gst_signing_class_init(GstSigningClass *klass)
   // Install properties
   g_object_class_install_property(gobject_class, PROP_BASETIME,
       g_param_spec_uint64("basetime", "Default basetime", "Basetime", 0, UINT64_MAX, 0,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+  g_object_class_install_property(gobject_class, PROP_CERT_SEI,
+      g_param_spec_int("certseiinterval", "Certificate SEI interval",
+          "CertificateSEIInterval", -1, INT32_MAX, 0,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 }
 
@@ -296,6 +312,19 @@ gst_signing_transform_ip(GstBaseTransform *trans, GstBuffer *buf)
   GstClockTime cur_pts = priv->last_pts + priv->basetime;
   const gint64 timestamp_100nsec = (const gint64)convert_unix_us_to_1601(cur_pts / 1000);
 
+  // Generate a Certificate SEI at startup if the feature is used.
+  if ((frame_count == 0 && priv->cert_sei_interval == 0) ||
+      (priv->cert_sei_interval > 0 && ((frame_count % priv->cert_sei_interval) == 0))) {
+    MediaSigningReturnCode oms_rc =
+        onvif_media_signing_generate_certificate_sei(priv->media_signing);
+    if (oms_rc != OMS_OK) {
+      GST_ELEMENT_ERROR(signing, STREAM, FAILED,
+          ("failed to generate certificate SEI, error %d", oms_rc), (NULL));
+      goto generate_sei_failed;
+    }
+  }
+  frame_count++;
+
   GST_DEBUG_OBJECT(signing, "got buffer with %d memories", gst_buffer_n_memory(buf));
   while (idx < gst_buffer_n_memory(buf)) {
     MediaSigningReturnCode oms_rc;
@@ -387,6 +416,7 @@ get_seis_failed:
 add_nalu_failed:
   gst_memory_unmap(nalu_mem, &map_info);
 map_failed:
+generate_sei_failed:
   return GST_FLOW_ERROR;
 }
 
@@ -491,12 +521,18 @@ setup_signing(GstSigning *signing, GstCaps *caps)
     GST_ERROR_OBJECT(signing, "failed to set properties");
     goto vendor_info_failed;
   }
+  if (onvif_media_signing_set_use_certificate_sei(
+          priv->media_signing, (priv->cert_sei_interval >= 0)) != OMS_OK) {
+    GST_ERROR_OBJECT(signing, "failed to set use certificate sei");
+    goto cert_sei_failed;
+  }
 
   g_free(certificate_chain);
   g_free(private_key);
 
   return TRUE;
 
+cert_sei_failed:
 vendor_info_failed:
 set_private_key_failed:
 read_private_key_failed:

--- a/examples/apps/signer/main.c
+++ b/examples/apps/signer/main.c
@@ -115,6 +115,9 @@ main(gint argc, gchar *argv[])
       "Optional\n"
       "  -h, --help       : This usage print.\n"
       "  -c codec         : 'h264' (default if omitted) or 'h265'.\n"
+      "  -C repetition    : Use certificate SEI. If 'repetition' is set to 0 only one\n"
+      "                     is at the beginning. Otherwise a new certificate SEI is\n"
+      "                     generated every 'repetition' frame.\n"
       "Required\n"
       "  filename         : Name of the file to be signed.\n"
       "Output\n"
@@ -127,6 +130,7 @@ main(gint argc, gchar *argv[])
   gchar *codec_str = "h264";
   gchar *demux_str = "";
   gchar *mux_str = "";
+  int cert_sei_repetition = -1;
 
   GstElement *pipeline = NULL;
   GstElement *filesrc = NULL;
@@ -154,6 +158,9 @@ main(gint argc, gchar *argv[])
     } else if (strcmp(argv[arg], "-c") == 0) {
       arg++;
       codec_str = argv[arg];
+    } else if (strcmp(argv[arg], "-C") == 0) {
+      arg++;
+      cert_sei_repetition = atoi(argv[arg]);
     } else if (strncmp(argv[arg], "-", 1) == 0) {
       // Unknown option.
       g_message("Unknown option: %s\n%s", argv[arg], usage);
@@ -249,6 +256,7 @@ main(gint argc, gchar *argv[])
     goto error_mediasigning;
   }
   gst_object_ref_sink(mediasigning);
+  g_object_set(G_OBJECT(mediasigning), "certseiinterval", cert_sei_repetition, NULL);
   // Set current time.
   {
     GstClockTime current_time_ns = time(NULL) * 100000000;

--- a/lib/src/includes/onvif_media_signing_signer.h
+++ b/lib/src/includes/onvif_media_signing_signer.h
@@ -423,7 +423,7 @@ onvif_media_signing_set_max_signing_frames(onvif_media_signing_t *self,
  *
  * ONVIF Media Signing allows the signing part to transmit information needed by the
  * validation side only once, such as the public key embedded in a certificate chain.
-
+ *
  * The default behavior is to continuously transmit everything necessary to verify a
  * signature, that is, not to use the certificate SEI concept.
  * NOTE: This function has to be called before the session starts.

--- a/lib/src/oms_common.c
+++ b/lib/src/oms_common.c
@@ -952,7 +952,7 @@ hash_and_add(onvif_media_signing_t *self, const nalu_info_t *nalu_info)
     // hash'.
     hash_wrapper_t hash_wrapper = get_hash_wrapper(self, nalu_info);
     OMS_THROW(hash_wrapper(self, nalu_info, nalu_hash, hash_size));
-    if (nalu_info->is_last_nalu_part) {
+    if (nalu_info->is_last_nalu_part && !nalu_info->is_certificate_sei) {
       OMS_THROW(update_gop_hash(self->crypto_handle, nalu_hash));
       // The end of the NAL Unit has been reached. Update the hash list.
       check_and_copy_hash_to_hash_list(self, nalu_hash, hash_size);

--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -356,15 +356,17 @@ generate_sei_and_add_to_buffer(onvif_media_signing_t *self, bool force_signature
       free(nalu_info_without_signature_data.nalu_wo_epb);
     }
 
-    // Reset the |num_frames_in_partial_gop| since a new partial GOP is started.
-    gop_info->num_frames_in_partial_gop = 0;
-    // Reset the |hash_list| by rewinding the |hash_list_idx| since a new (partial) GOP is
-    // triggered.
-    gop_info->hash_list_idx = 0;
-    // Initialize the gop_hash by resetting it.
-    OMS_THROW(openssl_init_hash(self->crypto_handle, true));
-    // End of (partial) GOP. Reset flag to get new reference.
-    gop_info->has_anchor_hash = false;
+    if (!self->is_certificate_sei) {
+      // Reset the |num_frames_in_partial_gop| since a new partial GOP is started.
+      gop_info->num_frames_in_partial_gop = 0;
+      // Reset the |hash_list| by rewinding the |hash_list_idx| since a new (partial) GOP
+      // is triggered.
+      gop_info->hash_list_idx = 0;
+      // Initialize the gop_hash by resetting it.
+      OMS_THROW(openssl_init_hash(self->crypto_handle, true));
+      // End of (partial) GOP. Reset flag to get new reference.
+      gop_info->has_anchor_hash = false;
+    }
 
     if (sign_this_sei) {
       OMS_THROW(onvif_media_signing_plugin_sign(

--- a/lib/src/oms_validator.c
+++ b/lib/src/oms_validator.c
@@ -893,19 +893,19 @@ prepare_for_validation(onvif_media_signing_t *self, nalu_list_item_t **sei)
       } else {
         (*sei)->validation_status_if_sei_ok = '.';
       }
-      validation_flags->validate_certificate_sei = (*sei)->nalu_info->is_certificate_sei;
     } else if (validation_flags->num_lost_seis < 0) {
       if ((*sei)->nalu_info->is_signed) {
         (*sei)->tmp_validation_status = 'N';
       } else {
         (*sei)->validation_status_if_sei_ok = 'N';
       }
-      validation_flags->validate_certificate_sei = (*sei)->nalu_info->is_certificate_sei;
     }
+    validation_flags->validate_certificate_sei = (*sei)->nalu_info->is_certificate_sei;
     if (!validation_flags->validate_certificate_sei) {
       OMS_THROW(compute_gop_hash(self, *sei));
       OMS_THROW(maybe_update_linked_hash(self, *sei));
     } else {
+      self->use_certificate_sei = true;
       self->latest_validation->authenticity =
           (*sei)->verified_signature == 1 ? OMS_AUTHENTICITY_OK : OMS_AUTHENTICITY_NOT_OK;
     }
@@ -1226,6 +1226,19 @@ register_nalu(onvif_media_signing_t *self, nalu_list_item_t *item)
       // TODO: Decide what to do if verification fails. Should mark public key as not
       // present?
       DEBUG_LOG("Verified SEI signature with result %d", item->verified_signature);
+      // If this is a certificate SEI, decode it and mark it accordingly.
+      if (self->use_certificate_sei && nalu_info->is_certificate_sei) {
+        // Decode the SEI
+        const uint8_t *tlv_data = nalu_info->tlv_data;
+        size_t tlv_size = nalu_info->tlv_size;
+
+        OMS_THROW_WITH_MSG(
+            decode_sei_data(self, tlv_data, tlv_size), "Failed decoding Certificate SEI");
+        item->has_been_decoded = true;
+        // Mark the SEI accordingly.
+        item->validation_status = item->verified_signature == 1 ? '.' : 'N';
+        item->tmp_validation_status = item->validation_status;
+      }
     }
   OMS_CATCH()
   OMS_DONE(status)

--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -781,6 +781,43 @@ START_TEST(certificate_sei_later)
 }
 END_TEST
 
+START_TEST(two_certificate_seis)
+{
+  // Device side
+  struct oms_setting setting = settings[_i];
+  setting.with_certificate_sei = true;
+  test_stream_t *list = create_signed_nalus("IPPIPPPIPPPIP", setting);
+  test_stream_check_types(list, "CIPPISPPPISPPPISP");
+  test_stream_item_t *cert_sei = test_stream_item_get(list, 1);
+  test_stream_item_check_type(cert_sei, 'C');
+  uint8_t *cert_data = malloc(cert_sei->data_size);
+  memcpy(cert_data, cert_sei->data, cert_sei->data_size);
+  test_stream_item_t *cert_sei2 =
+      test_stream_item_create(cert_data, cert_sei->data_size, setting.codec);
+  test_stream_append_item(list, cert_sei2, 8);
+  test_stream_check_types(list, "CIPPISPPCPISPPPISP");
+
+  // Client side
+  //
+  // CIPPISPPCPISPPPISP
+  //
+  // C                  .                   (valid, 0 pending)
+  //  IPPIS              ...P.              (valid, 1 pending)
+  //     ISPPCPIS           .....P.         (valid, 1 pending)
+  //           ISPPPIS           .....P.    (valid, 1 pending)
+  //                                                3 pending
+  //                ISP               P.P   (valid, 3 pending)
+  onvif_media_signing_accumulated_validation_t final_validation = {
+      OMS_AUTHENTICITY_AND_PROVENANCE_OK, OMS_PROVENANCE_OK, false, OMS_AUTHENTICITY_OK,
+      18, 15, 3, 13, 11, 2, 0, 0};
+  const struct validation_stats expected = {
+      .valid = 4, .pending_nalus = 3, .final_validation = &final_validation};
+  validate_test_stream(NULL, list, expected, setting.ec_key);
+
+  test_stream_free(list);
+}
+END_TEST
+
 START_TEST(no_trusted_certificate_added)
 {
   // Device side
@@ -2550,6 +2587,7 @@ onvif_media_signing_validator_suite(void)
   tcase_add_loop_test(tc, file_export_and_scrubbing, s, e);
   tcase_add_loop_test(tc, certificate_sei_first, s, e);
   tcase_add_loop_test(tc, certificate_sei_later, s, e);
+  tcase_add_loop_test(tc, two_certificate_seis, s, e);
   tcase_add_loop_test(tc, no_trusted_certificate_added, s, e);
   // Tampering cases
   tcase_add_loop_test(tc, interchange_two_p_frames, s, e);


### PR DESCRIPTION
The onvif_media_signing_generate_certificate_sei() function
can now safely be used at any time during a session to add
additional certificate SEIs.
The signer example app has been updated with an option
to add certificate SEIs at a certain repetition.
