### PR TITLE
Adds the possibility to store multiple trusted certificates

### DIFF
--- a/examples/apps/validator/main.c
+++ b/examples/apps/validator/main.c
@@ -496,7 +496,7 @@ setup_media_signing(MediaSigningCodec codec, const char *cert_filename)
   }
   if (success) {
     if (onvif_media_signing_set_trusted_certificate(
-            oms, trusted_certificate, trusted_certificate_size, false) != OMS_OK) {
+            oms, trusted_certificate, trusted_certificate_size) != OMS_OK) {
       g_message("Failed setting trusted certificate. Validating without one.");
     }
   } else {

--- a/lib/src/includes/onvif_media_signing_validator.h
+++ b/lib/src/includes/onvif_media_signing_validator.h
@@ -445,22 +445,19 @@ onvif_media_signing_add_nalu_and_authenticate(onvif_media_signing_t *self,
  *
  * The trusted certificate is expected to be in PEM format.
  *
- * NOTE: that this function can be called twice to store two trusted certificates, one for
- * manufactured provisioned signing and one for user provisioned signing.
+ * NOTE: that this function can be called multiple times to store multiple trusted
+ * certificates, both for manufacturer provisioned and user provisioned signing.
  *
  * @param self                     Pointer to the current ONVIF Media Signing session
  * @param trusted_certificate      Pointer to the trusted certificate in PEM format
  * @param trusted_certificate_size Size of the |trusted_certificate|
- * @param user_provisioned         Flag to select between either user or manufactured
- *                                 provisioned
  *
  * @return An ONVIF Media Signing Return Code
  */
 MediaSigningReturnCode
 onvif_media_signing_set_trusted_certificate(onvif_media_signing_t *self,
     const char *trusted_certificate,
-    size_t trusted_certificate_size,
-    bool user_provisioned);
+    size_t trusted_certificate_size);
 
 /**
  * @brief Identifies a certificate SEI

--- a/lib/src/oms_openssl.c
+++ b/lib/src/oms_openssl.c
@@ -27,6 +27,7 @@
 #include <openssl/bio.h>  // BIO_*
 #include <openssl/bn.h>  // BN_*
 #include <openssl/ec.h>  // EC_*
+#include <openssl/err.h>  // ERR_*
 #include <openssl/evp.h>  // EVP_*
 #include <openssl/objects.h>  // OBJ_*
 #include <openssl/pem.h>  // PEM_*
@@ -58,8 +59,7 @@ typedef struct {
   EVP_MD_CTX *primary_ctx;  // Use this for hash operations in both signing and validation
   EVP_MD_CTX *secondary_ctx;  // Use this in case another hash context is needed
   message_digest_t hash_algo;
-  X509_STORE *trust_anchor;
-  X509_STORE *trust_anchor_user_provisioned;
+  X509_STORE *trust_anchors;
   int verified_leaf_certificate;
   int verified_leaf_certificate_user_provisioned;
 } openssl_crypto_t;
@@ -137,8 +137,7 @@ openssl_store_private_key(sign_or_verify_data_t *sign_data,
 oms_rc
 openssl_set_trusted_certificate(void *handle,
     const char *trusted_certificate,
-    size_t trusted_certificate_size,
-    bool user_provisioned)
+    size_t trusted_certificate_size)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
 
@@ -148,12 +147,9 @@ openssl_set_trusted_certificate(void *handle,
 
   BIO *trusted_bio = NULL;
   X509 *trusted_certificate_x509 = NULL;
-  X509_STORE **trusted_anchor =
-      user_provisioned ? &self->trust_anchor_user_provisioned : &self->trust_anchor;
 
   oms_rc status = OMS_UNKNOWN_FAILURE;
   OMS_TRY()
-    OMS_THROW_IF(*trusted_anchor, OMS_NOT_SUPPORTED);
     // Intermediate store the |trusted_certificate| in X509 format.
     trusted_bio = BIO_new(BIO_s_mem());
     OMS_THROW_IF(!trusted_bio, OMS_EXTERNAL_ERROR);
@@ -161,15 +157,12 @@ openssl_set_trusted_certificate(void *handle,
         BIO_write(trusted_bio, trusted_certificate, (int)trusted_certificate_size) <= 0,
         OMS_EXTERNAL_ERROR);
     trusted_certificate_x509 = PEM_read_bio_X509(trusted_bio, NULL, NULL, NULL);
-    *trusted_anchor = X509_STORE_new();
-    OMS_THROW_IF(!*trusted_anchor, OMS_EXTERNAL_ERROR);
     // Load trusted CA certificate
-    OMS_THROW_IF(X509_STORE_add_cert(*trusted_anchor, trusted_certificate_x509) != 1,
+    OMS_THROW_IF(X509_STORE_add_cert(self->trust_anchors, trusted_certificate_x509) != 1,
         OMS_EXTERNAL_ERROR);
   OMS_CATCH()
   {
-    X509_STORE_free(*trusted_anchor);
-    *trusted_anchor = NULL;
+    ERR_clear_error();
   }
   OMS_DONE(status)
 
@@ -193,8 +186,6 @@ openssl_verify_certificate_chain(void *handle,
 
   // TODO: There should be a check that the root certificate of |certificate_chain| is
   // different from the trusted CA certificate.
-  X509_STORE *trusted_anchor =
-      user_provisioned ? self->trust_anchor_user_provisioned : self->trust_anchor;
   STACK_OF(X509) *untrusted_certificates = NULL;
   BIO *stackbio = NULL;
   int num_certificates = 0;
@@ -233,15 +224,19 @@ openssl_verify_certificate_chain(void *handle,
     // |untrusted_certificates|. The |leaf_cert| of the |untrusted_certificates| will be
     // verified.
     X509 *leaf_cert = sk_X509_value(untrusted_certificates, 0);
-    OMS_THROW_IF(
-        X509_STORE_CTX_init(ctx, trusted_anchor, leaf_cert, untrusted_certificates) != 1,
+    OMS_THROW_IF(X509_STORE_CTX_init(
+                     ctx, self->trust_anchors, leaf_cert, untrusted_certificates) != 1,
         OMS_EXTERNAL_ERROR);
-    // Check number of certificates in chain.
-    int read_num_certificates = X509_STORE_CTX_get_num_untrusted(ctx);
-    OMS_THROW_IF(read_num_certificates != num_certificates - 1, OMS_EXTERNAL_ERROR);
-    OMS_THROW_IF(num_certificates == MAX_NUM_CERTIFICATES, OMS_EXTERNAL_ERROR);
     // Verify the certificate chain and store the result.
     *verified = X509_verify_cert(ctx);
+    if (*verified == 0) {
+      DEBUG_LOG("Certificate verification error: %s\n",
+          X509_verify_cert_error_string(X509_STORE_CTX_get_error(ctx)));
+    }
+    // Check number of certificates in chain.
+    int read_num_certificates = X509_STORE_CTX_get_num_untrusted(ctx);
+    OMS_THROW_IF(read_num_certificates != num_certificates, OMS_EXTERNAL_ERROR);
+    OMS_THROW_IF(num_certificates == MAX_NUM_CERTIFICATES, OMS_EXTERNAL_ERROR);
   OMS_CATCH()
   OMS_DONE(status)
 
@@ -641,16 +636,11 @@ openssl_get_pubkey_verification(void *handle, bool user_provisioned)
 }
 
 bool
-openssl_has_trusted_certificate(void *handle, bool user_provisioned)
+openssl_has_trusted_certificate(void *handle)
 {
   openssl_crypto_t *self = (openssl_crypto_t *)handle;
-  if (!self) {
-    return false;
-  }
-  X509_STORE *trusted_anchor =
-      user_provisioned ? self->trust_anchor_user_provisioned : self->trust_anchor;
 
-  return trusted_anchor != NULL;
+  return self && (self->trust_anchors != NULL);
 }
 
 /* Creates a |handle| with a EVP_MD_CTX and hash algo. */
@@ -664,8 +654,9 @@ openssl_create_handle(void)
 
   self->verified_leaf_certificate = -1;
   self->verified_leaf_certificate_user_provisioned = -1;
+  self->trust_anchors = X509_STORE_new();
 
-  if (openssl_set_hash_algo(self, DEFAULT_HASH_ALGO) != OMS_OK) {
+  if (!self->trust_anchors || openssl_set_hash_algo(self, DEFAULT_HASH_ALGO) != OMS_OK) {
     openssl_free_handle(self);
     self = NULL;
   }
@@ -681,8 +672,7 @@ openssl_free_handle(void *handle)
   if (!self) {
     return;
   }
-  X509_STORE_free(self->trust_anchor);
-  X509_STORE_free(self->trust_anchor_user_provisioned);
+  X509_STORE_free(self->trust_anchors);
   EVP_MD_CTX_free(self->primary_ctx);
   EVP_MD_CTX_free(self->secondary_ctx);
   free(self->hash_algo.encoded_oid);

--- a/lib/src/oms_openssl_internal.h
+++ b/lib/src/oms_openssl_internal.h
@@ -305,23 +305,21 @@ openssl_store_public_key(sign_or_verify_data_t *verify_data, pem_cert_t *certifi
  * @brief Stores a trusted certificate
  *
  * The function reads a trusted certificate and stores it as a X509_STORE object.
+ * The trust store allows multiple trusted certificates to be stored, but this function
+ * only adds one at a time.
  *
  * @param handle Pointer to the OpenSSL cryptographic handle.
  * @param trusted_certificate A pointer to the trusted certificate in PEM format.
  * @param trusted_certificate_size The size of |trusted_certificate|.
- * @param user_provisioned Selects between manufacturer (false) and user (true)
- * provisioned.
  *
  * @return OMS_OK Successfully stored |trusted_certificate|,
  *         OMS_INVALID_PARAMETER Missing inputs,
- *         OMS_NOT_SUPPORTED |trusted_certificate| already set,
  *         OMS_EXTERNAL_FAILURE Failure in OpenSSL.
  */
 oms_rc
 openssl_set_trusted_certificate(void *handle,
     const char *trusted_certificate,
-    size_t trusted_certificate_size,
-    bool user_provisioned);
+    size_t trusted_certificate_size);
 
 /**
  * @brief Stores a certificate chain
@@ -365,12 +363,10 @@ openssl_get_pubkey_verification(void *handle, bool user_provisioned);
  * @brief Checks if a trusted certificate has been set
  *
  * @param handle Pointer to the OpenSSL cryptographic handle.
- * @param user_provisioned Selects between manufacturer (false) and user (true)
- * provisioned.
  *
  * @return Trusted certificate exists (true), otherwise (false).
  */
 bool
-openssl_has_trusted_certificate(void *handle, bool user_provisioned);
+openssl_has_trusted_certificate(void *handle);
 
 #endif  // __OMS_OPENSSL_INTERNAL_H__

--- a/lib/src/oms_signer.c
+++ b/lib/src/oms_signer.c
@@ -800,8 +800,7 @@ onvif_media_signing_set_signing_key_pair(onvif_media_signing_t *self,
     self->certificate_chain.key_size = stripped_size;
     // Verify that the certificate chain is complete and feasible to verify.
     OMS_THROW(openssl_set_trusted_certificate(self->crypto_handle,
-        &certificate_chain[stripped_size], certificate_chain_size - stripped_size,
-        user_provisioned));
+        &certificate_chain[stripped_size], certificate_chain_size - stripped_size));
     OMS_THROW(openssl_verify_certificate_chain(self->crypto_handle,
         self->certificate_chain.key, self->certificate_chain.key_size, user_provisioned));
 

--- a/lib/src/oms_validator.c
+++ b/lib/src/oms_validator.c
@@ -1132,7 +1132,7 @@ maybe_validate_gop(onvif_media_signing_t *self, nalu_info_t *nalu_info)
       // Update the provenance.
       switch (self->verified_pubkey) {
         case 1:
-          latest->provenance = openssl_has_trusted_certificate(self->crypto_handle, false)
+          latest->provenance = openssl_has_trusted_certificate(self->crypto_handle)
               ? OMS_PROVENANCE_OK
               : OMS_PROVENANCE_FEASIBLE_WITHOUT_TRUSTED;
           break;
@@ -1415,17 +1415,12 @@ onvif_media_signing_add_nalu_and_authenticate(onvif_media_signing_t *self,
 MediaSigningReturnCode
 onvif_media_signing_set_trusted_certificate(onvif_media_signing_t *self,
     const char *trusted_certificate,
-    size_t trusted_certificate_size,
-    bool user_provisioned)
+    size_t trusted_certificate_size)
 {
   if (!self || !trusted_certificate || trusted_certificate_size == 0) {
     return OMS_INVALID_PARAMETER;
   }
-  if (user_provisioned) {
-    // User provisioned signing is not yet supported.
-    return OMS_NOT_SUPPORTED;
-  }
 
-  return openssl_set_trusted_certificate(self->crypto_handle, trusted_certificate,
-      trusted_certificate_size, user_provisioned);
+  return openssl_set_trusted_certificate(
+      self->crypto_handle, trusted_certificate, trusted_certificate_size);
 }

--- a/tests/check/check_onvif_media_signing_validator.c
+++ b/tests/check/check_onvif_media_signing_validator.c
@@ -255,16 +255,14 @@ START_TEST(invalid_api_inputs)
   ck_assert_int_eq(onvif_media_signing_is_sei(oms, test_nalu, 0), 0);
 
   MediaSigningReturnCode omsrc =
-      onvif_media_signing_set_trusted_certificate(NULL, NULL, 0, false);
+      onvif_media_signing_set_trusted_certificate(NULL, NULL, 0);
   ck_assert_int_eq(omsrc, OMS_INVALID_PARAMETER);
-  omsrc =
-      onvif_media_signing_set_trusted_certificate(oms, test_data, TEST_DATA_SIZE, true);
-  ck_assert_int_eq(omsrc, OMS_NOT_SUPPORTED);
   // Set a trusted certificate. Note that true certificate data has to be set. This helper
   // function reads a certificate and sets it.
   ck_assert(test_helper_set_trusted_certificate(oms));
-  // Setting the trusted certificate a second time should fail.
-  ck_assert(!test_helper_set_trusted_certificate(oms));
+  // Setting the trusted certificate a second time should work.
+  // TODO: Add a different certificate to test with.
+  ck_assert(test_helper_set_trusted_certificate(oms));
 
   omsrc = onvif_media_signing_add_nalu_and_authenticate(
       NULL, test_nalu, TEST_DATA_SIZE, NULL);

--- a/tests/check/test_helpers.c
+++ b/tests/check/test_helpers.c
@@ -455,7 +455,7 @@ test_helper_set_trusted_certificate(onvif_media_signing_t *oms)
       oms_read_test_trusted_certificate(&trusted_certificate, &trusted_certificate_size));
 
   MediaSigningReturnCode oms_rc = onvif_media_signing_set_trusted_certificate(
-      oms, trusted_certificate, trusted_certificate_size, false);
+      oms, trusted_certificate, trusted_certificate_size);
   free(trusted_certificate);
   return (oms_rc == OMS_OK);
 }


### PR DESCRIPTION
In addition, there is no need to distinguish between manufacturer
and user provisioning. Hence, affected places have the
user_provisioned flag removed.

This means that there is a breaking change in the validator API
onvif_media_signing_set_trusted_certificate(...).
